### PR TITLE
Add a warning to Makefile when composer is not globally accessible.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ build: tests
 	chmod +x deptrac.phar
 
 composer-install-dev:
-	composer install --dev --optimize-autoloader
+	COMPOSER-CMD := $(composer)
+	ifndef COMPOSER-CMD
+		$(error "Composer is not available globally.")
+	endif
+	COMPOSER-CMD install --dev --optimize-autoloader
 
 tests: composer-install-dev
 	./vendor/phpunit/phpunit/phpunit -c .


### PR DESCRIPTION
Provide a concise error message when `make build` fails because composer is not being installed globally.

will produce:
<img width="437" alt="screen shot 2016-04-30 at 12 05 18" src="https://cloud.githubusercontent.com/assets/2952726/14935280/daa96c2a-0ecb-11e6-9106-2936830dee79.png">
instead of:
<img width="323" alt="screen shot 2016-04-30 at 12 07 24" src="https://cloud.githubusercontent.com/assets/2952726/14935289/2208b4e0-0ecc-11e6-8b2d-672319e896f4.png">
