### PR TITLE
Analysis with violations returns a 0 exit code.

### DIFF
--- a/src/Command/AnalyzeCommand.php
+++ b/src/Command/AnalyzeCommand.php
@@ -132,7 +132,7 @@ class AnalyzeCommand extends Command
             }
         }
 
-        return !count($violations);
+        return count($violations) ? 1 : 0;
     }
 
     private function collectFiles(Configuration $configuration)


### PR DESCRIPTION
When running a deptrac analysis as part of a travis build the build passes even when the result shows violations.

The analysis should return a non-zero exit code when violations were found and otherwise return 0.