### PR TITLE
Review of OutputFormatterInterface

### DIFF
--- a/src/OutputFormatter/OutputFormatterInterface.php
+++ b/src/OutputFormatter/OutputFormatterInterface.php
@@ -7,12 +7,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 interface OutputFormatterInterface
 {
+    /**
+     * @return string Used as an identifier to access to the formatter or to display something more user-friendly to the
+     *                user when referring to the formatter.
+     *
+     * @example "graphviz"
+     */
     public function getName();
 
     /** @return OutputFormatterOption[] */
     public function configureOptions();
 
     /**
+     * Renders the final result.
+     *
      * @param DependencyContext    $dependencyContext
      * @param OutputInterface      $output
      * @param OutputFormatterInput $outputFormatterInput


### PR DESCRIPTION
Minor suggestion of changes while reviewing the interface:

- Attempt to give an explanation on what `::getName()` is used for (it's always a bit unclear when you have to implement a `::getName()` function, you never really now what kind of name is expected.
- Add missing return block (obvious that name is a string but could be nullable..., docblock removes all ambiguity)
