### PR TITLE
Fix build php.ini documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Supported Options:
 To build deptrac, clone this repository and ensure you have the build dependencies installed:
 
 - PHP in version 5.5.9 or above
-- `phar.readonly = On` in the php.ini
+- `phar.readonly = Off` in the php.ini
 - [Composer](https://getcomposer.org/)
 - [Box](http://box-project.github.io/box2/)
 - make


### PR DESCRIPTION
In order to be able to build deptrac ```phar.readonly = Off``` is needed, otherwise the following exception will be thrown:

    [UnexpectedValueException]                                                                                       
    creating archive "~/deptrac/deptrac.phar" disabled by the php.ini setting phar.readonly
