### PR TITLE
Add self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ this rule was violated.
 1. [Installation](#installation)
   1. [Download the phar (recommended)](#download-the-phar-recommended)
   1. [Optional dependency: Graphviz](#optional-dependency-graphviz)
+1. [Updating Deptrac](#updating-deptrac)
 1. [Run Deptrac](#run-deptrac)
 1. [Layers](#layers)
   1. [Collecting Layers](#collecting-layers)
@@ -147,6 +148,11 @@ sudo apt-get install graphviz
 ```
 
 Graphviz is also available for [Windows](http://www.graphviz.org/Download_windows.php): install the current stable release and append the binary path on the environment variable Path (like ``C:\Program Files (x86)\Graphviz2.38\bin``).
+
+
+## Updating Deptrac
+
+To update deptrac to the latest version just run `php deptrac.phar self-update`.
 
 
 ## Run Deptrac

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "php": ">=5.5.9",
         "graphp/graphviz": "0.2.*",
         "nikic/php-parser": "~2.0",
+        "padraic/phar-updater": "^1.0",
         "phpdocumentor/graphviz": "~1.0",
         "sensiolabs-de/astrunner": "dev-master",
         "symfony/config": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "75c7d4dad2e2117c51e352a6f981e894",
-    "content-hash": "5999369a67b9b0b7a04a9b9d24c384a9",
+    "hash": "d4718dca8c464f85a62b6956e7c8e165",
+    "content-hash": "7a66407f991fe3ada48c68f045ea4ac0",
     "packages": [
         {
             "name": "clue/graph",
@@ -194,6 +194,115 @@
                 "php"
             ],
             "time": "2016-02-28 19:48:28"
+        },
+        {
+            "name": "padraic/humbug_get_contents",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/padraic/file_get_contents.git",
+                "reference": "66797199019d0cb4529cb8d29c6f0b4c5085b53a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/padraic/file_get_contents/zipball/66797199019d0cb4529cb8d29c6f0b4c5085b53a",
+                "reference": "66797199019d0cb4529cb8d29c6f0b4c5085b53a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Humbug\\": "src/Humbug/"
+                },
+                "files": [
+                    "src/function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                }
+            ],
+            "description": "Secure wrapper for accessing HTTPS resources with file_get_contents for PHP 5.3+",
+            "homepage": "https://github.com/padraic/file_get_contents",
+            "keywords": [
+                "download",
+                "file_get_contents",
+                "http",
+                "https",
+                "ssl",
+                "tls"
+            ],
+            "time": "2015-04-22 18:45:00"
+        },
+        {
+            "name": "padraic/phar-updater",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/padraic/phar-updater.git",
+                "reference": "c17eeb3887dc4269d1b4837dc875d39e9f8149a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/padraic/phar-updater/zipball/c17eeb3887dc4269d1b4837dc875d39e9f8149a8",
+                "reference": "c17eeb3887dc4269d1b4837dc875d39e9f8149a8",
+                "shasum": ""
+            },
+            "require": {
+                "padraic/humbug_get_contents": "^1.0",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Humbug\\SelfUpdate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                }
+            ],
+            "description": "A thing to make PHAR self-updating easy and secure.",
+            "keywords": [
+                "humbug",
+                "phar",
+                "self-update",
+                "update"
+            ],
+            "time": "2016-01-05 23:08:01"
         },
         {
             "name": "phpdocumentor/graphviz",

--- a/deptrac.php
+++ b/deptrac.php
@@ -25,5 +25,6 @@ $container
 $application = new Application();
 $application->add($container->get('command_init'));
 $application->add($container->get('command_analyze'));
+$application->add($container->get('command_self_update'));
 $application->setDefaultCommand('analyze');
 $application->run();

--- a/services.xml
+++ b/services.xml
@@ -53,5 +53,19 @@
             <argument type="service" id="collector_factory"/>
         </service>
 
+        <service id="updater_strategy" class="SensioLabs\Deptrac\Updater\DeptracStrategy" />
+
+        <service id="updater" class="Humbug\SelfUpdate\Updater">
+            <argument>null</argument>
+            <!-- disable signed releases, otherwise will search for a .pubkey file for the PHAR -->
+            <argument>false</argument>
+            <call method="setStrategyObject">
+                <argument type="service" id="updater_strategy"/>
+            </call>
+        </service>
+
+        <service id="command_self_update" class="SensioLabs\Deptrac\Command\SelfUpdateCommand">
+            <argument type="service" id="updater"/>
+        </service>
     </services>
 </container>

--- a/src/Command/SelfUpdateCommand.php
+++ b/src/Command/SelfUpdateCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SensioLabs\Deptrac\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Humbug\SelfUpdate\Updater;
+use Humbug\SelfUpdate\Exception\HttpRequestException;
+
+class SelfUpdateCommand extends Command
+{
+    /**
+     * @var Updater
+     */
+    private $updater;
+
+    /**
+     * SelfUpdateCommand constructor.
+     *
+     * @param Updater $updater
+     */
+    public function __construct(Updater $updater)
+    {
+        $this->updater = $updater;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('self-update')
+            ->setAliases(array('selfupdate'))
+            ->setDescription('Updates deptrac.phar to the latest version.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('<info>Updating deptrac to latest version...</info>');
+
+        try {
+            if ($this->updater->update()) {
+                $output->writeln('<info>Deprac was successfully updated.</info>');
+
+                return 0;
+            }
+        } catch (HttpRequestException $e) {
+            $output->writeln('<error>Could update deptrac.</error>');
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return 1;
+        }
+
+        $output->writeln('<info>Deprac is already the latest version.</info>');
+    }
+}

--- a/src/Updater/DeptracStrategy.php
+++ b/src/Updater/DeptracStrategy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SensioLabs\Deptrac\Updater;
+
+use Humbug\SelfUpdate\Strategy\ShaStrategy;
+
+class DeptracStrategy extends ShaStrategy
+{
+    public function __construct()
+    {
+        $this->setPharUrl('http://get.sensiolabs.de/deptrac.phar');
+        $this->setVersionUrl('http://get.sensiolabs.de/deptrac.version');
+    }
+}


### PR DESCRIPTION
This is a proposal for the self-update command #13 to be used as base although it needs probably some modifications.

Since the latest ```deptrac.phar``` is hosted in ```http://get.sensiolabs.de/deptrac.phar```, I thought the following location can be used to indicate its version ```http://get.sensiolabs.de/deptrac.version``` (currently not existing and should be created by SensionLabs as they admin the continuous delivery process I guess), which will be used in the code to fetch the latest version and compare it with the running one.

@slde-flash Let me know, what do you think about this or if you need a more sophisticated solution :smiley:.


