### PR TITLE
Deptrac binary + composer auto symlink to bin dir

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,11 @@
             "url": "git@github.com:sensiolabs-de/astrunner.git",
             "type": "git"
         }
+    ],
+    "config": {
+        "bin-dir": "bin/"
+    },
+    "bin": [
+        "fastest"
     ]
-
 }

--- a/deptrac
+++ b/deptrac
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 require __DIR__.'/vendor/autoload.php';

--- a/deptrac
+++ b/deptrac
@@ -18,6 +18,14 @@ foreach ($files as $file) {
     }
 }
 
+if (!$found) {
+    die(
+        'You need to set up the project dependencies using the following commands:' . PHP_EOL .
+        'curl -s http://getcomposer.org/installer | php' . PHP_EOL .
+        'php composer.phar install' . PHP_EOL
+    );
+}
+
 use SensioLabs\Deptrac\CompilerPass\CollectorPass;
 use SensioLabs\Deptrac\CompilerPass\OutputFormatterPass;
 use Symfony\Component\Config\FileLocator;

--- a/deptrac
+++ b/deptrac
@@ -1,7 +1,22 @@
 #!/usr/bin/env php
 <?php
 
-require __DIR__.'/vendor/autoload.php';
+$files = array(
+    __DIR__ . '/vendor/autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../vendor/autoload.php',
+    __DIR__ . '/../../../vendor/autoload.php'
+);
+
+$found = false;
+
+foreach ($files as $file) {
+    if (file_exists($file)) {
+        require $file;
+        $found = true;
+        break;
+    }
+}
 
 use SensioLabs\Deptrac\CompilerPass\CollectorPass;
 use SensioLabs\Deptrac\CompilerPass\OutputFormatterPass;


### PR DESCRIPTION
It would be much easier, if we could simply add deptrac as dev dependency, and have composer automatically add its binary to `bin-dir`.

Installation notes:

```bash
composer require-dev sensiolabs-de/deptrac
bin/deptrac init
```