### PR TITLE
Remove composer deprecated option --dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build: tests
 	chmod +x deptrac.phar
 
 composer-install-dev:
-	$(COMPOSER_BIN) install --dev --optimize-autoloader
+	$(COMPOSER_BIN) install --optimize-autoloader
 
 tests: composer-install-dev
 	$(PHP_BIN) ./vendor/phpunit/phpunit/phpunit -c .


### PR DESCRIPTION
No need for `--dev` option since it's deprecated and used by default.