### PR TITLE
allow PHPUnit 5 too for forward compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "^4.8 || ^5.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
PHPUnit 4.x is not guaranteed to be fully compatible with PHP 7.
However, PHPUnit 5.x does not support PHP 5.5.