### PR TITLE
Fixed parsing of nullable return types

### DIFF
--- a/src/DependencyEmitter/BasicDependencyEmitter.php
+++ b/src/DependencyEmitter/BasicDependencyEmitter.php
@@ -123,7 +123,6 @@ class BasicDependencyEmitter implements DependencyEmitterInterface
             if (!$node->returnType instanceof NullableType) {
                 continue; // @codeCoverageIgnore
             }
-
             $buffer[] = new EmittedDependency(
                 $node->returnType->type,
                 $node->returnType->getLine(),

--- a/src/DependencyEmitter/BasicDependencyEmitter.php
+++ b/src/DependencyEmitter/BasicDependencyEmitter.php
@@ -123,9 +123,10 @@ class BasicDependencyEmitter implements DependencyEmitterInterface
             if (!$node->returnType instanceof NullableType) {
                 continue; // @codeCoverageIgnore
             }
+
             $buffer[] = new EmittedDependency(
-                $node->returnType->type->toString(),
-                $node->returnType->type->getLine(),
+                $node->returnType->type,
+                $node->returnType->getLine(),
                 'returntype'
             );
         }

--- a/src/Tests/DependencyEmitter/BasicDependencyEmitterTest.php
+++ b/src/Tests/DependencyEmitter/BasicDependencyEmitterTest.php
@@ -26,7 +26,7 @@ class BasicDependencyEmitterTest extends \PHPUnit_Framework_TestCase
             new \SplFileInfo(__DIR__.'/Fixtures/Foo.php')
         );
 
-        $this->assertCount(14, $deps);
+        $this->assertCount(15, $deps);
         $this->assertContains('Foo\Bar:4 on SomeUse', $deps);
         $this->assertContains('Foo\Bar:10 on Foo\SomeParam', $deps);
         $this->assertContains('Foo\Bar:10 on Foo\SomeClass', $deps);
@@ -41,5 +41,6 @@ class BasicDependencyEmitterTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Foo\Bar:32 on Foo\SomeClass', $deps);
         $this->assertContains('Foo\Bar:36 on Foo\string2', $deps);
         $this->assertContains('Foo\Bar:38 on string', $deps);
+        $this->assertContains('Foo\Bar:40 on string', $deps);
     }
 }

--- a/src/Tests/DependencyEmitter/BasicDependencyEmitterTest.php
+++ b/src/Tests/DependencyEmitter/BasicDependencyEmitterTest.php
@@ -26,7 +26,7 @@ class BasicDependencyEmitterTest extends \PHPUnit_Framework_TestCase
             new \SplFileInfo(__DIR__.'/Fixtures/Foo.php')
         );
 
-        $this->assertCount(15, $deps);
+        $this->assertCount(16, $deps);
         $this->assertContains('Foo\Bar:4 on SomeUse', $deps);
         $this->assertContains('Foo\Bar:10 on Foo\SomeParam', $deps);
         $this->assertContains('Foo\Bar:10 on Foo\SomeClass', $deps);
@@ -42,5 +42,6 @@ class BasicDependencyEmitterTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Foo\Bar:36 on Foo\string2', $deps);
         $this->assertContains('Foo\Bar:38 on string', $deps);
         $this->assertContains('Foo\Bar:40 on string', $deps);
+        $this->assertContains('Foo\Bar:42 on Foo\SomeClass', $deps);
     }
 }

--- a/src/Tests/DependencyEmitter/Fixtures/Foo.php
+++ b/src/Tests/DependencyEmitter/Fixtures/Foo.php
@@ -25,6 +25,8 @@ class Bar extends BarExtends implements BarInterface1, \BarInterface2 {
 
     public function baz(): ?\Some\NamespacedClass {}
 
+    public function foobaz(): ?string {}
+
     public function foobar(): void
     {
         new class { public function foo(): SomeClass {} };

--- a/src/Tests/DependencyEmitter/Fixtures/Foo.php
+++ b/src/Tests/DependencyEmitter/Fixtures/Foo.php
@@ -25,8 +25,6 @@ class Bar extends BarExtends implements BarInterface1, \BarInterface2 {
 
     public function baz(): ?\Some\NamespacedClass {}
 
-    public function foobaz(): ?string {}
-
     public function foobar(): void
     {
         new class { public function foo(): SomeClass {} };
@@ -38,5 +36,7 @@ class Bar extends BarExtends implements BarInterface1, \BarInterface2 {
         function () : string2 {};
 
         function () : \string {};
+
+        function () : ?string {};
     }
 }

--- a/src/Tests/DependencyEmitter/Fixtures/Foo.php
+++ b/src/Tests/DependencyEmitter/Fixtures/Foo.php
@@ -38,5 +38,7 @@ class Bar extends BarExtends implements BarInterface1, \BarInterface2 {
         function () : \string {};
 
         function () : ?string {};
+
+        function () : ?SomeClass {};
     }
 }


### PR DESCRIPTION
The emitter assumed that the `NullableType::$type` holds a `Name` node, this is however not the case as it is a plain string.