### PR TITLE
allow the "exclude_files" option to be omitted

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -21,9 +21,9 @@ class Configuration
         $options = (new OptionsResolver())->setRequired([
             'layers',
             'paths',
-            'exclude_files',
             'ruleset',
         ])
+        ->setDefault('exclude_files', [])
         ->addAllowedTypes('layers', 'array')
         ->addAllowedTypes('paths', 'array')
         ->addAllowedTypes('exclude_files', ['array', 'null'])

--- a/src/Tests/ConfigurationTest.php
+++ b/src/Tests/ConfigurationTest.php
@@ -39,6 +39,31 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['xx', 'yy'], $configuration->getRuleset()->getAllowedDependendencies('lala'));
     }
 
+    public function testExludedFilesAreOptional()
+    {
+        $configuration = Configuration::fromArray([
+            'layers' => [
+                [
+                   'name' => 'some_name',
+                   'collectors' => [],
+                ],
+                [
+                   'name' => 'some_name',
+                   'collectors' => [],
+                ],
+            ],
+            'paths' => [
+                'foo',
+                'bar',
+            ],
+            'ruleset' => [
+                'lala' => ['xx', 'yy'],
+            ],
+        ]);
+
+        $this->assertSame([], $configuration->getExcludeFiles());
+    }
+
     public function testFromWithNullExcludeFiles()
     {
         $configuration = Configuration::fromArray([


### PR DESCRIPTION
IMO it's perfectly valid to not have to use the `exclude_files` options if, for example, source and test directory are separated and you do not want to exclude any source files. Currently, you would have to set this option explicitly to just be an empty sequence.