### PR TITLE
Make deptrac work as a regular dependency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/examples export-ignore
+/tests export-ignore

--- a/bin/deptrac
+++ b/bin/deptrac
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/../deptrac.php';

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
             "email": "tim.glabisch@sensiolabs.de"
         }
     ],
+    "bin": [
+        "bin/deptrac"
+    ],
     "require-dev": {
         "phpunit/phpunit": "^6.5"
     },

--- a/deptrac.php
+++ b/deptrac.php
@@ -1,6 +1,16 @@
 <?php
 
-require __DIR__.'/vendor/autoload.php';
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require __DIR__ . '/vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../autoload.php')) {
+    require __DIR__ . '/../../autoload.php';
+} else {
+    die(
+        'You must set up the project dependencies, run the following commands:'.PHP_EOL.
+        'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
+        'php composer.phar install'.PHP_EOL
+    );
+}
 
 use SensioLabs\Deptrac\Command\AnalyzeCommand;
 use SensioLabs\Deptrac\Command\InitCommand;


### PR DESCRIPTION
### Summary of changes

* in deptrac.php: Find autoload.php when deptrac is installed as a dependency, or fail gracefully.
* in composer.json and bin/deptrac: expose main entry point to Composer (it automatically creates a softlink at vendor/bin/deptrac).
* .gitattributes: exclude non-essential files from Packagist releases (see https://madewithlove.be/gitattributes/)