### PR TITLE
Upgrade to Box3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ deptrac.phar
 depfile.yml
 phpunit.xml
 box.json
+deptrac.version
+junit-report.xml

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,7 @@ SHA1SUM		 := sha1sum
 .PHONY: build composer-install-dev tests tests-coverage
 
 build: tests
-	$(COMPOSER_BIN) install --no-dev --optimize-autoloader
-	$(BOX_BIN) build
-	chmod +x deptrac.phar
+	$(BOX_BIN) compile
 	$(SHA1SUM) deptrac.phar > deptrac.version
 
 composer-install-dev:

--- a/box.json.dist
+++ b/box.json.dist
@@ -1,12 +1,6 @@
 {
-  "directories": [
-    "src",
-    "vendor"
-  ],
   "files": [
     "services.xml"
   ],
-  "main": "deptrac.php",
-  "output": "deptrac.phar",
-  "stub": true
+  "main": "deptrac.php"
 }


### PR DESCRIPTION
I'm actually not sure if you were using Box 2 or Box 3, but in any case the following works with Box 3.1.

List of the changes:
- Simplify the `box.json.dist` config by removing the redundant settings `stub` and `output`
- Remove the `directories` setting of the `box.json.dist` config allowing Box to do the auto-discovery of the files to include. This allows Box to easily remove the dev dependencies so there is no longer a need to do a `composer install --no-dev`
- Simplify the `make build`
  - Remove the unnecessary `chmod +x` since the generated PHAR is already an executable
  - Remove the now unnecessary `composer install --no-dev`
  - Rename `box build` to `box compile` (the previous command name has been deprecated)
- Add the files generated by `make build` to `.gitignore`


