### PR TITLE
Implemented skip violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,40 @@ Found 2 Violations
 Deptrac has found two violations because the relation from the controller to model layers is not allowed.
 The console output shows exactly the lines deptrac found.
 
+### Skip violations
+
+Deptrac integration into existing CI/CD pipeline might be difficult because of existing dependency violations in the code.
+In this case, you can skip existing violations to gradually improve your code and avoid possibility introduce any new violations.
+
+Violations can be skipped by provided list of dependencies in *skip_violations* configuration section:
+```yaml
+skip_violations:
+  Library\LibClass:
+    - Core\CoreClass
+``` 
+*skip_violations* section contains associative array where a key (`Library\LibClass`) is the name of dependant class 
+and values (`Core\CoreClass`) are dependency classes.
+
+Matched violations will be marked as skipped:
+```bash
+php deptrac.php analyze examples/SkipViolations.yml
+```
+```text
+Start to create an AstMap for 1 Files.
+ ..
+AstMap created.
+start emitting dependencies "InheritanceDependencyEmitter"
+start emitting dependencies "BasicDependencyEmitter"
+end emitting dependencies
+start flatten dependencies
+end flatten dependencies
+collecting violations.
+formatting dependencies.
+[SKIPPED] Library\LibClass::11 must not depend on Core\CoreClass (Library on Core)
+
+Found 0 Violations and 1 Violations skipped
+``` 
+
 
 ## Ruleset (Allowing Dependencies)
 

--- a/examples/SkipViolations.yml
+++ b/examples/SkipViolations.yml
@@ -1,0 +1,16 @@
+paths: ["./examples/SkipViolations/"]
+layers:
+- name: Core
+  collectors:
+  - type: className
+    regex: Core
+- name: Library
+  collectors:
+  - type: className
+    regex: Library
+ruleset:
+  Core:
+  - Library
+skip_violations:
+  Library\LibClass:
+    - Core\CoreClass

--- a/examples/SkipViolations/SkipViolations.php
+++ b/examples/SkipViolations/SkipViolations.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Core;
+
+use Library\LibClass;
+
+class CoreClass {}
+
+namespace Library;
+
+use Core\CoreClass;
+
+class LibClass {}

--- a/src/Command/AnalyzeCommand.php
+++ b/src/Command/AnalyzeCommand.php
@@ -98,12 +98,14 @@ class AnalyzeCommand extends Command
         /** @var RulesetEngine\RulesetViolation[] $violations */
         $violations = $this->rulesetEngine->getViolations($dependencyResult, $classNameLayerResolver, $configuration->getRuleset());
 
+        $skippedViolations = $this->rulesetEngine->getSkippedViolations($violations, $configuration->getSkipViolations());
+
         $this->printFormattingStart($output);
 
         foreach ($this->formatterFactory->getActiveFormatters($input) as $formatter) {
             try {
                 $formatter->finish(
-                    new DependencyContext($astMap, $violations, $dependencyResult, $classNameLayerResolver),
+                    new DependencyContext($astMap, $violations, $dependencyResult, $classNameLayerResolver, $skippedViolations),
                     $output,
                     $this->formatterFactory->getOutputFormatterInput($formatter, $input)
                 );
@@ -112,7 +114,7 @@ class AnalyzeCommand extends Command
             }
         }
 
-        return count($violations) ? 1 : 0;
+        return (count($violations) - count($skippedViolations)) ? 1 : 0;
     }
 
     protected function printBanner(OutputInterface $output): void

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -12,6 +12,7 @@ class Configuration
     private $paths;
     private $excludeFiles;
     private $ruleset;
+    private $skipViolations;
 
     public static function fromArray(array $arr): self
     {
@@ -21,10 +22,12 @@ class Configuration
             'ruleset',
         ])
         ->setDefault('exclude_files', [])
+        ->setDefault('skip_violations', [])
         ->addAllowedTypes('layers', 'array')
         ->addAllowedTypes('paths', 'array')
         ->addAllowedTypes('exclude_files', ['array', 'null'])
         ->addAllowedTypes('ruleset', 'array')
+        ->addAllowedTypes('skip_violations', 'array')
         ->resolve($arr);
 
         return new static(
@@ -33,6 +36,7 @@ class Configuration
             }, $options['layers']),
             ConfigurationRuleset::fromArray($options['ruleset']),
             $options['paths'],
+            ConfigurationSkippedViolation::fromArray($options['skip_violations']),
             (array) $options['exclude_files']
         );
     }
@@ -42,12 +46,13 @@ class Configuration
      * @param string[]             $paths
      * @param string[]             $excludeFiles
      */
-    private function __construct(array $layers, ConfigurationRuleset $ruleset, array $paths, array $excludeFiles = [])
+    private function __construct(array $layers, ConfigurationRuleset $ruleset, array $paths, ConfigurationSkippedViolation $skipViolations, array $excludeFiles = [])
     {
         $this->layers = $layers;
         $this->ruleset = $ruleset;
         $this->paths = $paths;
         $this->excludeFiles = $excludeFiles;
+        $this->skipViolations = $skipViolations;
     }
 
     /**
@@ -77,5 +82,10 @@ class Configuration
     public function getRuleset(): ConfigurationRuleset
     {
         return $this->ruleset;
+    }
+
+    public function getSkipViolations(): ConfigurationSkippedViolation
+    {
+        return $this->skipViolations;
     }
 }

--- a/src/Configuration/ConfigurationSkippedViolation.php
+++ b/src/Configuration/ConfigurationSkippedViolation.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SensioLabs\Deptrac\Configuration;
+
+/**
+ * @author Dmitry Balabka <dmitry.balabka@gmail.com>
+ */
+class ConfigurationSkippedViolation
+{
+    private $classesDeps = [];
+
+    public static function fromArray(array $arr): self
+    {
+        return new static($arr);
+    }
+
+    /**
+     * @param string[] $classesDeps
+     */
+    private function __construct(array $classesDeps)
+    {
+        $this->classesDeps = $classesDeps;
+    }
+
+    public function isViolationSkipped(string $classA, string $classB): bool
+    {
+        return isset($this->classesDeps[$classA]) && \in_array($classB, $this->classesDeps[$classA], true);
+    }
+}

--- a/src/DependencyContext.php
+++ b/src/DependencyContext.php
@@ -12,7 +12,6 @@ class DependencyContext
 {
     /** @var AstMap */
     private $astMap;
-
     /** @var RulesetViolation[] */
     private $violations;
 
@@ -22,21 +21,27 @@ class DependencyContext
     /** @var ClassNameLayerResolverInterface */
     private $classNameLayerResolver;
 
+    /** @var RulesetViolation[] */
+    private $skippedViolations;
+
     /**
      * DependencyContext constructor.
      *
      * @param RulesetEngine\RulesetViolation[] $violations
+     * @param RulesetEngine\RulesetViolation[] $skippedViolations
      */
     public function __construct(
         AstMap $astMap,
         array $violations,
         Result $dependencyResult,
-        ClassNameLayerResolverInterface $classNameLayerResolver
+        ClassNameLayerResolverInterface $classNameLayerResolver,
+        array $skippedViolations = []
     ) {
         $this->astMap = $astMap;
         $this->violations = $violations;
         $this->dependencyResult = $dependencyResult;
         $this->classNameLayerResolver = $classNameLayerResolver;
+        $this->skippedViolations = $skippedViolations;
     }
 
     public function getAstMap(): AstMap
@@ -70,5 +75,33 @@ class DependencyContext
     public function getClassNameLayerResolver(): ClassNameLayerResolverInterface
     {
         return $this->classNameLayerResolver;
+    }
+
+    /**
+     * @return RulesetViolation[]
+     */
+    public function getSkippedViolationsByLayerName(string $layerName): array
+    {
+        return array_values(
+            array_filter(
+                $this->skippedViolations,
+                function (RulesetViolation $violation) use ($layerName) {
+                    return $violation->getLayerA() === $layerName;
+                }
+            )
+        );
+    }
+
+    /**
+     * @return RulesetViolation[]
+     */
+    public function getSkippedViolations(): array
+    {
+        return $this->skippedViolations;
+    }
+
+    public function isViolationSkipped(RulesetViolation $violation): bool
+    {
+        return \in_array($violation, $this->skippedViolations, true);
     }
 }

--- a/src/RulesetEngine.php
+++ b/src/RulesetEngine.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SensioLabs\Deptrac;
 
 use SensioLabs\Deptrac\Configuration\ConfigurationRuleset;
+use SensioLabs\Deptrac\Configuration\ConfigurationSkippedViolation;
 use SensioLabs\Deptrac\Dependency\Result;
 use SensioLabs\Deptrac\RulesetEngine\RulesetViolation;
 
@@ -44,5 +45,22 @@ class RulesetEngine
         }
 
         return $violations;
+    }
+
+    /**
+     * @param RulesetViolation[] $violations
+     *
+     * @return RulesetViolation[]
+     */
+    public function getSkippedViolations(array $violations, ConfigurationSkippedViolation $configurationSkipViolation): array
+    {
+        return \array_values(
+            \array_filter($violations, function ($violation) use ($configurationSkipViolation) {
+                /** @var RulesetViolation $violation */
+                $dep = $violation->getDependency();
+
+                return $configurationSkipViolation->isViolationSkipped($dep->getClassA(), $dep->getClassB());
+            })
+        );
     }
 }

--- a/tests/Configuration/ConfigurationSkippedViolationTest.php
+++ b/tests/Configuration/ConfigurationSkippedViolationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SensioLabs\Deptrac\Configuration;
+
+use PHPUnit\Framework\TestCase;
+use SensioLabs\Deptrac\Configuration\ConfigurationSkippedViolation;
+
+class ConfigurationSkippedViolationTest extends TestCase
+{
+    public function testFromArray(): void
+    {
+        $configuration = ConfigurationSkippedViolation::fromArray([
+            'ClassWithOneDep' => [
+                'DependencyClass',
+            ],
+            'ClassWithEmptyDeps' => [],
+            'ClassWithMultipleDeps' => [
+                'DependencyClass1',
+                'DependencyClass2',
+                'DependencyClass2',
+            ],
+        ]);
+        $this->assertTrue($configuration->isViolationSkipped('ClassWithOneDep', 'DependencyClass'));
+        $this->assertFalse($configuration->isViolationSkipped('ClassWithEmptyDeps', 'DependencyClass'));
+        $this->assertTrue($configuration->isViolationSkipped('ClassWithMultipleDeps', 'DependencyClass1'));
+        $this->assertTrue($configuration->isViolationSkipped('ClassWithMultipleDeps', 'DependencyClass2'));
+    }
+
+    public function testFromArrayWithEmptyArrayAcceptable()
+    {
+        $configuration = ConfigurationSkippedViolation::fromArray([]);
+        $this->assertFalse($configuration->isViolationSkipped('AnyClass', 'AnotherAnyClass'));
+    }
+
+    public function testFromArrayRequireOneArgument()
+    {
+        $this->expectException(\TypeError::class);
+        ConfigurationSkippedViolation::fromArray();
+    }
+}

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -78,4 +78,23 @@ class ConfigurationTest extends TestCase
 
         static::assertEquals([], $configuration->getExcludeFiles());
     }
+
+    public function testSkipViolations(): void
+    {
+        $configuration = Configuration::fromArray([
+            'layers' => [],
+            'paths' => [],
+            'exclude_files' => null,
+            'ruleset' => [],
+            'skip_violations' => [
+                'FooClass' => [
+                    'BarClass',
+                    'AnotherClass',
+                ],
+            ],
+        ]);
+
+        static::assertTrue($configuration->getSkipViolations()->isViolationSkipped('FooClass', 'BarClass'));
+        static::assertTrue($configuration->getSkipViolations()->isViolationSkipped('FooClass', 'AnotherClass'));
+    }
 }

--- a/tests/DependencyContextTest.php
+++ b/tests/DependencyContextTest.php
@@ -9,6 +9,8 @@ use SensioLabs\Deptrac\AstRunner\AstMap;
 use SensioLabs\Deptrac\ClassNameLayerResolverInterface;
 use SensioLabs\Deptrac\Dependency\Result;
 use SensioLabs\Deptrac\DependencyContext;
+use SensioLabs\Deptrac\DependencyResult\Dependency;
+use SensioLabs\Deptrac\RulesetEngine\RulesetViolation;
 
 class DependencyContextTest extends TestCase
 {
@@ -25,5 +27,73 @@ class DependencyContextTest extends TestCase
         static::assertEquals([1, 2, 3], $context->getViolations());
         static::assertSame($dependencyResult, $context->getDependencyResult());
         static::assertSame($classNameLayerResolver, $context->getClassNameLayerResolver());
+    }
+
+    public function testIsViolationSkipped(): void
+    {
+        $violations = [
+            new RulesetViolation(
+                new Dependency('ClassA', 12, 'ClassB'),
+                'LayerA',
+                'LayerB'
+            ),
+        ];
+        $context = new DependencyContext(
+            $astMap = $this->prophesize(AstMap::class)->reveal(),
+            [],
+            $dependencyResult = $this->prophesize(Result::class)->reveal(),
+            $classNameLayerResolver = $this->prophesize(ClassNameLayerResolverInterface::class)->reveal(),
+            $violations
+        );
+        $this->assertSame($violations, $context->getSkippedViolations());
+    }
+
+    public function testGetSkippedViolationsByLayerName(): void
+    {
+        $violations = [
+            new RulesetViolation(
+                new Dependency('ClassA', 12, 'ClassB'),
+                'LayerA',
+                'LayerB'
+            ),
+            $matchedViolation = new RulesetViolation(
+                new Dependency('ClassA', 12, 'ClassB'),
+                'LayerC',
+                'LayerD'
+            ),
+        ];
+        $context = new DependencyContext(
+            $astMap = $this->prophesize(AstMap::class)->reveal(),
+            [],
+            $dependencyResult = $this->prophesize(Result::class)->reveal(),
+            $classNameLayerResolver = $this->prophesize(ClassNameLayerResolverInterface::class)->reveal(),
+            $violations
+        );
+        $this->assertSame([$matchedViolation], $context->getSkippedViolationsByLayerName('LayerC'));
+        $this->assertSame([], $context->getSkippedViolationsByLayerName('LayerB'));
+    }
+
+    public function testGetSkippedViolations(): void
+    {
+        $violations = [
+            new RulesetViolation(
+                new Dependency('ClassA', 12, 'ClassB'),
+                'LayerA',
+                'LayerB'
+            ),
+            $matchedViolation = new RulesetViolation(
+                new Dependency('ClassA', 12, 'ClassB'),
+                'LayerC',
+                'LayerD'
+            ),
+        ];
+        $context = new DependencyContext(
+            $astMap = $this->prophesize(AstMap::class)->reveal(),
+            [],
+            $dependencyResult = $this->prophesize(Result::class)->reveal(),
+            $classNameLayerResolver = $this->prophesize(ClassNameLayerResolverInterface::class)->reveal(),
+            $violations
+        );
+        $this->assertSame($violations, $context->getSkippedViolations());
     }
 }

--- a/tests/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -46,6 +46,7 @@ class ConsoleOutputFormatterTest extends TestCase
                     'LayerB'
                 ),
             ],
+            [],
             '
                 ClassA must not depend on ClassB (LayerA on LayerB)
                 ClassInheritD::6 ->
@@ -66,6 +67,7 @@ class ConsoleOutputFormatterTest extends TestCase
                     'LayerB'
                 ),
             ],
+            [],
             '
                 OriginalA::12 must not depend on OriginalB (LayerA on LayerB)
 
@@ -76,9 +78,26 @@ class ConsoleOutputFormatterTest extends TestCase
         yield [
             [
             ],
+            [],
             '
 
                 Found 0 Violations
+            ',
+        ];
+
+        yield [
+            [
+                $violation = new RulesetViolation(
+                    new Dependency('OriginalA', 12, 'OriginalB'),
+                    'LayerA',
+                    'LayerB'
+                ),
+            ],
+            [
+                $violation,
+            ],
+            '[SKIPPED] OriginalA::12 must not depend on OriginalB (LayerA on LayerB)
+            Found 0 Violations and 1 Violations skipped
             ',
         ];
     }
@@ -86,7 +105,7 @@ class ConsoleOutputFormatterTest extends TestCase
     /**
      * @dataProvider basicDataProvider
      */
-    public function testBasic(array $violations, string $expectedOutput): void
+    public function testBasic(array $violations, array $skippedViolations, string $expectedOutput): void
     {
         $output = new BufferedOutput();
 
@@ -96,7 +115,8 @@ class ConsoleOutputFormatterTest extends TestCase
                 $this->prophesize(AstMap::class)->reveal(),
                 $violations,
                 $this->prophesize(Result::class)->reveal(),
-                $this->prophesize(ClassNameLayerResolverInterface::class)->reveal()
+                $this->prophesize(ClassNameLayerResolverInterface::class)->reveal(),
+                $skippedViolations
             ),
             $output,
             new OutputFormatterInput([])
@@ -116,6 +136,6 @@ class ConsoleOutputFormatterTest extends TestCase
 
     private function normalize($str)
     {
-        return str_replace(["\t", "\n", ' '], '', $str);
+        return str_replace(["\r", "\t", "\n", ' '], '', $str);
     }
 }

--- a/tests/OutputFormatter/data/expected-junit-report-with-skipped-violations.xml
+++ b/tests/OutputFormatter/data/expected-junit-report-with-skipped-violations.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<testsuites>
+    <testsuite errors="0" failures="1" hostname="localhost" id="1" name="LayerA" package="" skipped="1" tests="2" time="0">
+        <testcase classname="ClassA" name="LayerA - ClassA" time="0">
+            <skipped/>
+        </testcase>
+        <testcase classname="ClassC" name="LayerA - ClassC" time="0">
+            <failure message="ClassC:0 must not depend on ClassD (LayerA on LayerB)" type="WARNING"/>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/tests/OutputFormatter/data/expected-junit-report_1.xml
+++ b/tests/OutputFormatter/data/expected-junit-report_1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite id="1" package="" name="LayerA" hostname="localhost" tests="1" failures="1" errors="0" time="0">
+  <testsuite id="1" package="" name="LayerA" hostname="localhost" tests="1" failures="1" skipped="0" errors="0" time="0">
     <testcase name="LayerA - ClassA" classname="ClassA" time="0">
       <failure message="ClassA:0 must not depend on ClassB (LayerA on LayerB)" type="WARNING"/>
     </testcase>

--- a/tests/OutputFormatter/data/expected-junit-report_2.xml
+++ b/tests/OutputFormatter/data/expected-junit-report_2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
-  <testsuite id="1" package="" name="LayerA" hostname="localhost" tests="1" failures="1" errors="0" time="0">
+  <testsuite id="1" package="" name="LayerA" hostname="localhost" tests="1" failures="1" skipped="0" errors="0" time="0">
     <testcase name="LayerA - OriginalA" classname="OriginalA" time="0">
       <failure message="OriginalA:12 must not depend on OriginalB (LayerA on LayerB)" type="WARNING"/>
     </testcase>


### PR DESCRIPTION
Initial implementation of #199

## Scope
Implement possibility to skip class dependency violation in `depfile.yml`. There will be new configuration section `skip_violations` (maybe `skipped_violations` better?). The developer can configure it in the following way:
```yaml
skip_violations:
  Library\LibClass:
    - Core\CoreClass
    - Core\AnotherClass
```
`skip_violations` section contains associative array where key (`Library\LibClass`) is the name of dependant class and values (`Core\CoreClass`, `Core\AnotherClass`) are dependency classes.

## Future scope
There might be implemented possibility for PHP functions dependency as well. In this case, we can specify functions names instead of class names. PHP allows to create functions with names which can be equal to class names in the same namespace:
```php
<?php

namespace Foo;

class bar {
    function __invoke()
    {
        echo __CLASS__ . PHP_EOL;
    }
}

function bar() {
    echo __FUNCTION__ . PHP_EOL;
}

bar();
(new bar())();
```
output:
```text
Foo\bar
Foo\bar
```
So function names should be identified differently from clasess. We can sufix each function name with `()`:
```yaml
skip_violations:
  Library\LibClass:
    - Foo\bar()
    - Foo\bar
```

## TODO
- [x] Implement class violations skipping possibility
- [x] Unit tests
- [x] Update documentation

