### PR TITLE
enable gz compression + php-scoper

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -1,11 +1,13 @@
 {
   "compactors": [
-    "Herrera\\Box\\Compactor\\Php",
-    "Herrera\\Box\\Compactor\\Json"
+    "KevinGH\\Box\\Compactor\\Json",
+    "KevinGH\\Box\\Compactor\\Php",
+    "KevinGH\\Box\\Compactor\\PhpScoper"
   ],
   "files": [
     "services.xml"
   ],
+  "compression": "GZ",
   "main": "deptrac.php",
   "git-version": "git-version"
 }


### PR DESCRIPTION
When gz-compression is enable the phar-file size will be reduced to just 632 KB instead of 3.24 MB.
It might not be a thing having a dependency on zlib as it is should be enabled/installed by default (on linux/unix).