### PR TITLE
allow single file exclusions

### DIFF
--- a/src/FileResolver.php
+++ b/src/FileResolver.php
@@ -28,7 +28,11 @@ class FileResolver
 
         return array_filter($files, function (\SplFileInfo $fileInfo) use ($configuration) {
             foreach ($configuration->getExcludeFiles() as $excludeFiles) {
-                if (preg_match('/'.$excludeFiles.'/i', $fileInfo->getPathname())) {
+                if (preg_match('/^([.A-Za-z\/])+(\.php)$/', $excludeFiles)) {
+                    if ($excludeFiles === $fileInfo->getPathname()) {
+                        return false;
+                    }
+                } elseif (preg_match('/'.$excludeFiles.'/i', $fileInfo->getPathname())) {
                     return false;
                 }
             }


### PR DESCRIPTION
In order to use deptrac in a mature project with multiple layer violations, we want to be able to exclude a list of files (instead of regexs) generated by our pre-commit hooks, so we can force our devs to fix the violations of the files they modified instead of explicitly work on a huge one-time refactor.

I found that the exclusion system of the FileResolver is always expecting a regex and breaks if you try to exclude a file path. With this change we resolve the iteration of the array_filter earlier if the config line has a file path format.

Since you don't have tests for this file, you can manually test this fix creating a depfile to analyze the tool itself:
```
paths:
  - ./src
exclude_files:
  - ./src/OutputFormatter/JUnitOutputFormatter.php
  - .*OutputFormatterInterface.*
layers:
  - name: Dependency
    collectors:
      - type: className
        regex: .*Dependency.*
  - name: OutputFormatter
    collectors:
      - type: className
        regex: .*OutputFormatter.*
ruleset:
  Dependency:
    - OutputFormatter
```