### PR TITLE
Fix: Remove non-applicable exclude configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,10 +13,6 @@
     </testsuites>
     <filter>
         <whitelist>
-            <exclude>
-                <directory>./src/Command</directory>
-                <directory>./src/CompilerPass</directory>
-            </exclude>
             <directory>./src</directory>
         </whitelist>
     </filter>


### PR DESCRIPTION
This PR

* [x] removes non-applicable exclude configuration