### PR TITLE
Enhancement: Enable static_lambda fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -13,6 +13,7 @@ return PhpCsFixer\Config::create()
         'no_empty_phpdoc' => true,
         'no_superfluous_phpdoc_tags' => true,
         'no_unused_imports' => true,
+        'static_lambda' => true,
         'strict_param' => true,
     ])
     ->setFinder($finder);

--- a/src/AstRunner/AstParser/AstFileReferenceFileCache.php
+++ b/src/AstRunner/AstParser/AstFileReferenceFileCache.php
@@ -98,7 +98,7 @@ class AstFileReferenceFileCache implements AstFileReferenceCache
         }
 
         $this->cache = array_map(
-            function (array $data): array {
+            static function (array $data): array {
                 $data['reference'] = unserialize(
                     $data['reference'],
                     [
@@ -132,7 +132,7 @@ class AstFileReferenceFileCache implements AstFileReferenceCache
         );
 
         $payload = array_map(
-            function (array $data): array {
+            static function (array $data): array {
                 $data['reference'] = serialize($data['reference']);
 
                 return $data;

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -31,7 +31,7 @@ class Configuration
         ->resolve($arr);
 
         return new static(
-            array_map(function ($v): ConfigurationLayer {
+            array_map(static function ($v): ConfigurationLayer {
                 return ConfigurationLayer::fromArray($v);
             }, $options['layers']),
             ConfigurationRuleset::fromArray($options['ruleset']),

--- a/src/Configuration/ConfigurationLayer.php
+++ b/src/Configuration/ConfigurationLayer.php
@@ -21,7 +21,7 @@ class ConfigurationLayer
         ])->resolve($arr);
 
         return new static(
-            array_map(function ($v): ConfigurationCollector {
+            array_map(static function ($v): ConfigurationCollector {
                 return ConfigurationCollector::fromArray($v);
             }, $options['collectors']),
             $options['name']

--- a/src/OutputFormatterFactory.php
+++ b/src/OutputFormatterFactory.php
@@ -91,7 +91,7 @@ class OutputFormatterFactory
             $name,
             implode(
                 ', ',
-                array_map(function (OutputFormatterInterface $f): string {
+                array_map(static function (OutputFormatterInterface $f): string {
                     return $f->getName();
                 }, $this->formatters)
             )


### PR DESCRIPTION
This PR

* [x] enables the `static_lambda` fixer
* [x] runs `php-cs-fixer`

💁‍♂ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.15.1#usage:

>**static_lambda**
>
>Lambdas not (indirect) referencing `$this` must be declared `static`.
>
>_Risky rule: risky when using `->bindTo` on lambdas without referencing to `$this`._

