### PR TITLE
Enhancement: Throw exception when configuration cannot be parsed as yaml

### DIFF
--- a/src/Configuration/Exception/FileCannotBeParsedAsYamlException.php
+++ b/src/Configuration/Exception/FileCannotBeParsedAsYamlException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SensioLabs\Deptrac\Configuration\Exception;
+
+final class FileCannotBeParsedAsYamlException extends \RuntimeException
+{
+    public static function fromFilename(string $filename): self
+    {
+        return new self(sprintf(
+            'File "%s" cannot be parsed as YAML.',
+            $filename
+        ));
+    }
+}

--- a/src/Configuration/Loader.php
+++ b/src/Configuration/Loader.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace SensioLabs\Deptrac\Configuration;
 
+use SensioLabs\Deptrac\Configuration\Exception\FileCannotBeParsedAsYamlException;
 use SensioLabs\Deptrac\Configuration\Exception\MissingFileException;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 class Loader
 {
     /**
      * @throws MissingFileException
+     * @throws FileCannotBeParsedAsYamlException
      */
     public function load(string $file): Configuration
     {
@@ -18,8 +21,12 @@ class Loader
             throw new MissingFileException();
         }
 
-        return Configuration::fromArray(
-            Yaml::parse(file_get_contents($file))
-        );
+        try {
+            $data = Yaml::parse(file_get_contents($file));
+        } catch (ParseException $exception) {
+            throw FileCannotBeParsedAsYamlException::fromFilename($file);
+        }
+
+        return Configuration::fromArray($data);
     }
 }

--- a/tests/Configuration/Exception/FileCannotBeParsedAsYamlExceptionTest.php
+++ b/tests/Configuration/Exception/FileCannotBeParsedAsYamlExceptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SensioLabs\Deptrac\Configuration\Exception;
+
+use PHPUnit\Framework\TestCase;
+use SensioLabs\Deptrac\Configuration\Exception\FileCannotBeParsedAsYamlException;
+
+/**
+ * @covers \SensioLabs\Deptrac\Configuration\Exception\FileCannotBeParsedAsYamlException
+ */
+final class FileCannotBeParsedAsYamlExceptionTest extends TestCase
+{
+    public function testIsRuntimeException(): void
+    {
+        $exception = new FileCannotBeParsedAsYamlException();
+
+        self::assertInstanceOf(\RuntimeException::class, $exception);
+    }
+
+    public function testFromFilenameReturnsException(): void
+    {
+        $filename = __FILE__;
+
+        $exception = FileCannotBeParsedAsYamlException::fromFilename($filename);
+
+        $message = sprintf(
+            'File "%s" cannot be parsed as YAML.',
+            $filename
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}

--- a/tests/Configuration/LoaderTest.php
+++ b/tests/Configuration/LoaderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SensioLabs\Deptrac\Configuration;
+
+use PHPUnit\Framework\TestCase;
+use SensioLabs\Deptrac\Configuration\Exception\FileCannotBeParsedAsYamlException;
+use SensioLabs\Deptrac\Configuration\Exception\MissingFileException;
+use SensioLabs\Deptrac\Configuration\Loader;
+
+/**
+ * @covers \SensioLabs\Deptrac\Configuration\Loader
+ */
+final class LoaderTest extends TestCase
+{
+    public function testLoadThrowsMissingFileExceptionWhenFileDoesNotExist(): void
+    {
+        $file = __DIR__.'/../../examples/non-existent-file.yml';
+
+        $loader = new Loader();
+
+        self::expectException(MissingFileException::class);
+
+        $loader->load($file);
+    }
+
+    public function testLoadThrowsFileCannotBeParsedAsYamlExceptionWhenFileDoesNotContainYaml(): void
+    {
+        $file = __FILE__;
+
+        $loader = new Loader();
+
+        self::expectException(FileCannotBeParsedAsYamlException::class);
+
+        $loader->load($file);
+    }
+}


### PR DESCRIPTION
This PR

* [x] throws an exception when configuration cannot be parsed as yaml

### Before

Running

```
$ php deptrac.php analyze composer.lock
```

yields

```
deptrac is alpha, not production ready.
please help us and report feedback / bugs.


In Parser.php line 391:

  Unable to parse at line 1 (near "{").


analyze [--formatter-graphviz [FORMATTER-GRAPHVIZ]] [--formatter-graphviz-display [FORMATTER-GRAPHVIZ-DISPLAY]] [--formatter-graphviz-dump-image [FORMATTER-GRAPHVIZ-DUMP-IMAGE]] [--formatter-graphviz-dump-dot [FORMATTER-GRAPHVIZ-DUMP-DOT]] [--formatter-graphviz-dump-html [FORMATTER-GRAPHVIZ-DUMP-HTML]] [--formatter-console [FORMATTER-CONSOLE]] [--formatter-junit [FORMATTER-JUNIT]] [--formatter-junit-dump-xml [FORMATTER-JUNIT-DUMP-XML]] [--no-banner] [--no-progress] [--] [<depfile>]
```

### After

Running

```
$ php deptrac.php analyze composer.lock
```

yields

```

deptrac is alpha, not production ready.
please help us and report feedback / bugs.


In FileCannotBeParsedAsYamlException.php line 11:

  File "composer.lock" cannot be parsed as YAML.


analyze [--formatter-graphviz [FORMATTER-GRAPHVIZ]] [--formatter-graphviz-display [FORMATTER-GRAPHVIZ-DISPLAY]] [--formatter-graphviz-dump-image [FORMATTER-GRAPHVIZ-DUMP-IMAGE]] [--formatter-graphviz-dump-dot [FORMATTER-GRAPHVIZ-DUMP-DOT]] [--formatter-graphviz-dump-html [FORMATTER-GRAPHVIZ-DUMP-HTML]] [--formatter-console [FORMATTER-CONSOLE]] [--formatter-junit [FORMATTER-JUNIT]] [--formatter-junit-dump-xml [FORMATTER-JUNIT-DUMP-XML]] [--no-banner] [--no-progress] [--] [<depfile>]
```
