### PR TITLE
Add SARB format

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -68,6 +68,10 @@
             <tag name="output_formatter"/>
         </service>
 
+        <service id="SensioLabs\Deptrac\OutputFormatter\SarbOutputFormatter">
+            <tag name="output_formatter"/>
+        </service>
+
         <service id="SensioLabs\Deptrac\RulesetEngine"/>
 
         <service id="SensioLabs\Deptrac\Collector\Registry">

--- a/src/Dependency/Dependency.php
+++ b/src/Dependency/Dependency.php
@@ -9,12 +9,14 @@ class Dependency implements DependencyInterface
     protected $classA;
     protected $classALine;
     protected $classB;
+    private $filename;
 
-    public function __construct(string $classA, int $classALine, string $classB)
+    public function __construct(string $filename, string $classA, int $classALine, string $classB)
     {
         $this->classA = $classA;
         $this->classALine = $classALine;
         $this->classB = $classB;
+        $this->filename = $filename;
     }
 
     public function getClassA(): string
@@ -30,5 +32,10 @@ class Dependency implements DependencyInterface
     public function getClassB(): string
     {
         return $this->classB;
+    }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
     }
 }

--- a/src/Dependency/DependencyInterface.php
+++ b/src/Dependency/DependencyInterface.php
@@ -11,4 +11,6 @@ interface DependencyInterface
     public function getClassALine(): int;
 
     public function getClassB(): string;
+
+    public function getFilename(): string;
 }

--- a/src/Dependency/InheritDependency.php
+++ b/src/Dependency/InheritDependency.php
@@ -12,13 +12,15 @@ class InheritDependency implements DependencyInterface
     private $classB;
     private $path;
     private $originalDependency;
+    private $filename;
 
-    public function __construct(string $classA, string $classB, DependencyInterface $originalDependency, AstInherit $path)
+    public function __construct(string $filename, string $classA, string $classB, DependencyInterface $originalDependency, AstInherit $path)
     {
         $this->classA = $classA;
         $this->classB = $classB;
         $this->originalDependency = $originalDependency;
         $this->path = $path;
+        $this->filename = $filename;
     }
 
     public function getClassA(): string
@@ -45,4 +47,10 @@ class InheritDependency implements DependencyInterface
     {
         return $this->originalDependency;
     }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
 }

--- a/src/Dependency/InheritanceFlatter.php
+++ b/src/Dependency/InheritanceFlatter.php
@@ -16,6 +16,7 @@ class InheritanceFlatter
             foreach ($astMap->getClassInherits($classReference->getClassName()) as $inherit) {
                 foreach ($dependencyResult->getDependenciesByClass($inherit->getClassName()) as $dep) {
                     $dependencyResult->addInheritDependency(new InheritDependency(
+                        $classReference->getClassName() . '.php',
                         $classReference->getClassName(),
                         $dep->getClassB(),
                         $dep,

--- a/src/DependencyEmitter/BasicDependencyEmitter.php
+++ b/src/DependencyEmitter/BasicDependencyEmitter.php
@@ -28,6 +28,7 @@ class BasicDependencyEmitter implements DependencyEmitterInterface
                 foreach ($dependencies as $emittedDependency) {
                     $dependencyResult->addDependency(
                         new Dependency(
+                            $astClassReference->getFileReference()->getFilepath(),
                             $astClassReference->getClassName(),
                             $emittedDependency->getLine(),
                             $emittedDependency->getClass()

--- a/src/DependencyEmitter/InheritanceDependencyEmitter.php
+++ b/src/DependencyEmitter/InheritanceDependencyEmitter.php
@@ -21,6 +21,7 @@ class InheritanceDependencyEmitter implements DependencyEmitterInterface
             foreach ($astMap->getClassInherits($classReference->getClassName()) as $inherit) {
                 $dependencyResult->addDependency(
                     new Dependency(
+                        $classReference->getFileReference()->getFilepath(),
                         $classReference->getClassName(),
                         $inherit->getLine(),
                         $inherit->getClassName()

--- a/src/OutputFormatter/SarbOutputFormatter.php
+++ b/src/OutputFormatter/SarbOutputFormatter.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SensioLabs\Deptrac\OutputFormatter;
+
+use SensioLabs\Deptrac\DependencyContext;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SarbOutputFormatter implements OutputFormatterInterface
+{
+    private static $argument_dump_sarb = 'dump-sarb';
+
+    public function getName(): string
+    {
+        return 'sarb';
+    }
+
+    /**
+     * @return OutputFormatterOption[]
+     */
+    public function configureOptions(): array
+    {
+        return [
+            OutputFormatterOption::newValueOption(static::$argument_dump_sarb, 'path to a dumped sarb file', './sarb.json'),
+        ];
+    }
+
+    public function enabledByDefault(): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    public function finish(
+        DependencyContext $dependencyContext,
+        OutputInterface $output,
+        OutputFormatterInput $outputFormatterInput
+    ): void {
+
+        $sarbIssues = [];
+
+        foreach ($dependencyContext->getViolations() as $violation) {
+
+            $dependency = $violation->getDependency();
+
+            $type = sprintf(
+                '%s on %s',
+                $violation->getLayerA(),
+                $violation->getLayerB()
+            );
+
+            $message = sprintf(
+                '%s:%s must not depend on %s (%s on %s)',
+                $dependency->getClassA(),
+                $dependency->getClassALine(),
+                $dependency->getClassB(),
+                $violation->getLayerA(),
+                $violation->getLayerB()
+            );
+
+            $sarbIssues[] = [
+                'file' => $dependency->getFilename(),
+                'line' => $dependency->getClassALine(),
+                'type' => $type,
+                'message' => $message,
+            ];
+        }
+
+
+        $json = json_encode($sarbIssues);
+
+        if ($dumpSarbPath = $outputFormatterInput->getOption(static::$argument_dump_sarb)) {
+            file_put_contents($dumpSarbPath, $json);
+            $output->writeln('<info>JUnit Report dumped to '.realpath($dumpSarbPath).'</info>');
+        }
+    }
+
+}

--- a/tests/Dependency/DependencyTest.php
+++ b/tests/Dependency/DependencyTest.php
@@ -11,7 +11,8 @@ class DependencyTest extends TestCase
 {
     public function testGetSet(): void
     {
-        $dependency = new Dependency('a', 23, 'b');
+        $dependency = new Dependency('ClassA.php','a', 23, 'b');
+        static::assertEquals('ClassA.php', $dependency->getFilename());
         static::assertEquals('a', $dependency->getClassA());
         static::assertEquals(23, $dependency->getClassALine());
         static::assertEquals('b', $dependency->getClassB());

--- a/tests/Dependency/InheritDependencyTest.php
+++ b/tests/Dependency/InheritDependencyTest.php
@@ -14,12 +14,14 @@ class InheritDependencyTest extends TestCase
     public function testGetSet(): void
     {
         $dependency = new InheritDependency(
+            '/home/src/filePath',
             'a',
             'b',
             $dep = $this->prophesize(DependencyInterface::class)->reveal(),
             $astInherit = $this->prophesize(AstInherit::class)->reveal()
         );
 
+        static::assertSame('/home/src/filePath', $dependency->getFilename());
         static::assertEquals('a', $dependency->getClassA());
         static::assertEquals('b', $dependency->getClassB());
         static::assertEquals(0, $dependency->getClassALine());

--- a/tests/Dependency/ResultTest.php
+++ b/tests/Dependency/ResultTest.php
@@ -15,9 +15,9 @@ class ResultTest extends TestCase
     public function testAddDependency(): void
     {
         $dependencyResult = new Result();
-        $dependencyResult->addDependency($dep1 = new Dependency('A', 12, 'B'));
-        $dependencyResult->addDependency($dep2 = new Dependency('B', 12, 'C'));
-        $dependencyResult->addDependency($dep3 = new Dependency('A', 12, 'C'));
+        $dependencyResult->addDependency($dep1 = new Dependency('A.php', 'A', 12, 'B'));
+        $dependencyResult->addDependency($dep2 = new Dependency('B.php', 'B', 12, 'C'));
+        $dependencyResult->addDependency($dep3 = new Dependency('A.php', 'A', 12, 'C'));
         static::assertSame([$dep1, $dep3], $dependencyResult->getDependenciesByClass('A'));
         static::assertSame([$dep2], $dependencyResult->getDependenciesByClass('B'));
         static::assertSame([], $dependencyResult->getDependenciesByClass('C'));
@@ -27,8 +27,8 @@ class ResultTest extends TestCase
     public function testGetDependenciesAndInheritDependencies(): void
     {
         $dependencyResult = new Result();
-        $dependencyResult->addDependency($dep1 = new Dependency('A', 12, 'B'));
-        $dependencyResult->addInheritDependency($dep2 = new InheritDependency('A', 'B', $dep1, AstInherit::newExtends('B', 12)));
+        $dependencyResult->addDependency($dep1 = new Dependency('A.php', 'A', 12, 'B'));
+        $dependencyResult->addInheritDependency($dep2 = new InheritDependency('A.php', 'A', 'B', $dep1, AstInherit::newExtends('B', 12)));
         static::assertEquals([$dep1, $dep2], $dependencyResult->getDependenciesAndInheritDependencies());
     }
 }

--- a/tests/DependencyContextTest.php
+++ b/tests/DependencyContextTest.php
@@ -33,7 +33,7 @@ class DependencyContextTest extends TestCase
     {
         $skippedViolations = [
             new RulesetViolation(
-                new Dependency('ClassA', 12, 'ClassB'),
+                new Dependency('ClassA.php','ClassA', 12, 'ClassB'),
                 'LayerA',
                 'LayerB'
             ),
@@ -52,12 +52,12 @@ class DependencyContextTest extends TestCase
     {
         $skippedViolations = [
             new RulesetViolation(
-                new Dependency('ClassA', 12, 'ClassB'),
+                new Dependency('ClassA.php','ClassA', 12, 'ClassB'),
                 'LayerA',
                 'LayerB'
             ),
             $matchedViolation = new RulesetViolation(
-                new Dependency('ClassA', 12, 'ClassB'),
+                new Dependency('ClassA.php','ClassA', 12, 'ClassB'),
                 'LayerC',
                 'LayerD'
             ),
@@ -77,12 +77,12 @@ class DependencyContextTest extends TestCase
     {
         $skippedViolations = [
             new RulesetViolation(
-                new Dependency('ClassA', 12, 'ClassB'),
+                new Dependency('ClassA.php', 'ClassA', 12, 'ClassB'),
                 'LayerA',
                 'LayerB'
             ),
             $matchedViolation = new RulesetViolation(
-                new Dependency('ClassA', 12, 'ClassB'),
+                new Dependency('ClassA.php','ClassA', 12, 'ClassB'),
                 'LayerC',
                 'LayerD'
             ),

--- a/tests/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -30,9 +30,10 @@ class ConsoleOutputFormatterTest extends TestCase
             [
                 new RulesetViolation(
                     new InheritDependency(
+                        'ClassA.php',
                         'ClassA',
                         'ClassB',
-                        new Dependency('OriginalA', 12, 'OriginalB'),
+                        new Dependency('OriginalA.php', 'OriginalA', 12, 'OriginalB'),
                         AstInherit::newExtends('ClassInheritA', 3)->withPath([
                             AstInherit::newExtends('ClassInheritB', 4),
                             AstInherit::newExtends('ClassInheritC', 5),
@@ -59,7 +60,7 @@ class ConsoleOutputFormatterTest extends TestCase
         yield [
             [
                 new RulesetViolation(
-                    new Dependency('OriginalA', 12, 'OriginalB'),
+                    new Dependency('OriginalA.php','OriginalA', 12, 'OriginalB'),
                     'LayerA',
                     'LayerB'
                 ),
@@ -84,7 +85,7 @@ class ConsoleOutputFormatterTest extends TestCase
         yield [
             [
                 $violation = new RulesetViolation(
-                    new Dependency('OriginalA', 12, 'OriginalB'),
+                    new Dependency('OriginalA.php','OriginalA', 12, 'OriginalB'),
                     'LayerA',
                     'LayerB'
                 ),

--- a/tests/OutputFormatter/JUnitOutputFormatterTest.php
+++ b/tests/OutputFormatter/JUnitOutputFormatterTest.php
@@ -43,9 +43,10 @@ class JUnitOutputFormatterTest extends TestCase
             [
                 new RulesetViolation(
                     new InheritDependency(
+                        'ClassA.php',
                         'ClassA',
                         'ClassB',
-                        new Dependency('OriginalA', 12, 'OriginalB'),
+                        new Dependency('OriginalA.php','OriginalA',  12, 'OriginalB'),
                         AstInherit::newExtends('ClassInheritA', 3)->withPath([
                             AstInherit::newExtends('ClassInheritB', 4),
                             AstInherit::newExtends('ClassInheritC', 5),
@@ -67,7 +68,7 @@ class JUnitOutputFormatterTest extends TestCase
             ],
             [
                 new RulesetViolation(
-                    new Dependency('OriginalA', 12, 'OriginalB'),
+                    new Dependency('OriginalA.php','OriginalA', 12, 'OriginalB'),
                     'LayerA',
                     'LayerB'
                 ),
@@ -93,9 +94,10 @@ class JUnitOutputFormatterTest extends TestCase
             [
                 $violations = new RulesetViolation(
                     new InheritDependency(
+                        'ClassA.php',
                         'ClassA',
                         'ClassB',
-                        new Dependency('OriginalA', 12, 'OriginalB'),
+                        new Dependency('OriginalA.php','OriginalA',  12, 'OriginalB'),
                         AstInherit::newExtends('ClassInheritA', 3)->withPath([
                             AstInherit::newExtends('ClassInheritB', 4),
                             AstInherit::newExtends('ClassInheritC', 5),
@@ -107,9 +109,10 @@ class JUnitOutputFormatterTest extends TestCase
                 ),
                 new RulesetViolation(
                     new InheritDependency(
+                        'ClassC.php',
                         'ClassC',
                         'ClassD',
-                        new Dependency('OriginalA', 12, 'OriginalB'),
+                        new Dependency('OriginalA.php', 'OriginalA', 12, 'OriginalB'),
                         AstInherit::newExtends('ClassInheritA', 3)->withPath([
                             AstInherit::newExtends('ClassInheritB', 4),
                             AstInherit::newExtends('ClassInheritC', 5),

--- a/tests/OutputFormatter/SarbOutputFormatterTest.php
+++ b/tests/OutputFormatter/SarbOutputFormatterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SensioLabs\Deptrac\OutputFormatter;
+
+use PHPUnit\Framework\TestCase;
+use SensioLabs\Deptrac\AstRunner\AstMap;
+use SensioLabs\Deptrac\ClassNameLayerResolverInterface;
+use SensioLabs\Deptrac\Dependency\Result;
+use SensioLabs\Deptrac\DependencyContext;
+use SensioLabs\Deptrac\Dependency\Dependency;
+use SensioLabs\Deptrac\OutputFormatter\OutputFormatterInput;
+use SensioLabs\Deptrac\OutputFormatter\SarbOutputFormatter;
+use SensioLabs\Deptrac\RulesetEngine\RulesetViolation;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class SarbOutputFormatterTest extends TestCase
+{
+    private static $actual_junit_report_file = 'actual-sarb.json';
+
+    public function tearDown(): void
+    {
+        if (file_exists(__DIR__ . '/data/' . static::$actual_junit_report_file)) {
+            unlink(__DIR__ . '/data/' . static::$actual_junit_report_file);
+        }
+    }
+
+    public function testGetName(): void
+    {
+        static::assertSame('sarb', (new SarbOutputFormatter())->getName());
+    }
+
+    public function testGenerateJson(): void
+    {
+        $violations = [
+            new RulesetViolation(
+                new Dependency(
+                    '/home/project/Person.php',
+                    'Acme\\Entity\\Person',
+                    12,
+                    'Acme\\Controller\\User'),
+                'Layer A',
+                'Layer B'),
+            new RulesetViolation(
+                new Dependency(
+                    '/home/project/User.php',
+                    'Acme\\Entity\\User',
+                    8,
+                    'Acme\\Controller\\Course'),
+                'Layer A',
+                'Layer B'),
+        ];
+
+
+        $output = new BufferedOutput();
+
+        $formatter = new SarbOutputFormatter();
+        $formatter->finish(
+            new DependencyContext(
+                $this->prophesize(AstMap::class)->reveal(),
+                $this->prophesize(Result::class)->reveal(),
+                $this->prophesize(ClassNameLayerResolverInterface::class)->reveal(),
+                $violations,
+                []
+            ),
+            $output,
+            new OutputFormatterInput(['dump-sarb' => __DIR__ . '/data/' . static::$actual_junit_report_file])
+        );
+
+        static::assertJsonFileEqualsJsonFile(
+            __DIR__ . '/data/' . static::$actual_junit_report_file,
+            __DIR__ . '/data/expected-sarb.json'
+        );
+    }
+
+    public function testGetOptions(): void
+    {
+        static::assertCount(1, (new SarbOutputFormatter())->configureOptions());
+    }
+}

--- a/tests/OutputFormatter/data/expected-sarb.json
+++ b/tests/OutputFormatter/data/expected-sarb.json
@@ -1,0 +1,14 @@
+[
+  {
+    "file" : "/home/project/Person.php",
+    "line" : 12,
+    "type" : "Layer A on Layer B",
+    "message" : "Acme\\Entity\\Person:12 must not depend on Acme\\Controller\\User (Layer A on Layer B)"
+  },
+  {
+    "file" : "/home/project/User.php",
+    "line" : 8,
+    "type" : "Layer A on Layer B",
+    "message" : "Acme\\Entity\\User:8 must not depend on Acme\\Controller\\Course (Layer A on Layer B)"
+  }
+]

--- a/tests/RulesetEngineTest.php
+++ b/tests/RulesetEngineTest.php
@@ -17,7 +17,7 @@ class RulesetEngineTest extends TestCase
     private function createDependencies(array $fromTo): iterable
     {
         foreach ($fromTo as $from => $to) {
-            yield new Dependency($from, 0, $to);
+            yield new Dependency($from . '.php', $from, 0, $to);
         }
     }
 
@@ -178,7 +178,7 @@ class RulesetEngineTest extends TestCase
             'not matched violations' => [
                 [
                     new RulesetEngine\RulesetViolation(
-                        new Dependency('ClassA', 12, 'ClassD'),
+                        new Dependency('ClassA.php','ClassA', 12, 'ClassD'),
                         'LayerA',
                         'LayerB'
                     ),
@@ -194,12 +194,12 @@ class RulesetEngineTest extends TestCase
             'has matched violations' => [
                 [
                     new RulesetEngine\RulesetViolation(
-                        new Dependency('ClassA', 12, 'ClassD'),
+                        new Dependency('ClassA.php','ClassA', 12, 'ClassD'),
                         'LayerA',
                         'LayerB'
                     ),
                     $matchedViolation = new RulesetEngine\RulesetViolation(
-                        new Dependency('ClassA', 12, 'ClassB'),
+                        new Dependency('ClassA.php','ClassA', 12, 'ClassB'),
                         'LayerA',
                         'LayerB'
                     ),


### PR DESCRIPTION
Possible fix for #268 

SARB needs to know the full path of the class where the violation happens. Commit 896a059 does do this, but I feel it is a bit messy. Is there a better way. Reflection in the OutputFormatter doesn't work. Maybe some other mechanism is possible?  