### PR TITLE
Add flag --fail-on-uncovered (closes #306)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -142,6 +142,9 @@ jobs:
       - name: "Custom cache file should exist"
         run: "[ -f '.deptrac.cache2' ]"
 
+      - name: "Run deptrac phar with --fail-on-uncovered"
+        run: sh .github/workflows/test-flag-fail-on-uncovered.sh
+
       - name: "Upload phar file artifact"
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-flag-fail-on-uncovered.sh
+++ b/.github/workflows/test-flag-fail-on-uncovered.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+php deptrac.php analyze examples/Uncovered.depfile.yaml --fail-on-uncovered
+
+if [ $? -ne 1 ]; then
+  exit 1;
+fi

--- a/examples/Uncovered.depfile.yaml
+++ b/examples/Uncovered.depfile.yaml
@@ -1,0 +1,9 @@
+paths: ["./examples/Uncovered/"]
+layers:
+  - name: Core
+    collectors:
+      - type: className
+        regex: Core
+
+ruleset:
+  Core: ~

--- a/examples/Uncovered/InternalClasses.php
+++ b/examples/Uncovered/InternalClasses.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Core;
+
+class CoreClass
+{
+    public function __construct()
+    {
+        new \Other\OtherClass();
+    }
+}
+
+namespace Other;
+
+class OtherClass {}

--- a/src/Console/Command/AnalyzeCommand.php
+++ b/src/Console/Command/AnalyzeCommand.php
@@ -46,7 +46,7 @@ class AnalyzeCommand extends Command
         $this->addArgument('depfile', InputArgument::OPTIONAL, 'Path to the depfile', getcwd().'/depfile.yml');
         $this->getDefinition()->addOptions($this->formatterFactory->getFormatterOptions());
         $this->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not show progress bar');
-        $this->addOption('fail-on-uncovered', false, InputOption::VALUE_NONE, 'Fails if any uncovered dependecy is found');
+        $this->addOption('fail-on-uncovered', null, InputOption::VALUE_NONE, 'Fails if any uncovered dependecy is found');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Console/Command/AnalyzeCommand.php
+++ b/src/Console/Command/AnalyzeCommand.php
@@ -46,6 +46,7 @@ class AnalyzeCommand extends Command
         $this->addArgument('depfile', InputArgument::OPTIONAL, 'Path to the depfile', getcwd().'/depfile.yml');
         $this->getDefinition()->addOptions($this->formatterFactory->getFormatterOptions());
         $this->addOption('no-progress', null, InputOption::VALUE_NONE, 'Do not show progress bar');
+        $this->addOption('fail-on-uncovered', false, InputOption::VALUE_NONE, 'Fails if any uncovered dependecy is found');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -80,6 +81,10 @@ class AnalyzeCommand extends Command
             } catch (\Exception $ex) {
                 $this->printFormatterException($output, $formatter->getName(), $ex);
             }
+        }
+
+        if ($input->getOption('fail-on-uncovered') && $context->hasUncovered()) {
+            return 1;
         }
 
         return $context->hasViolations() ? 1 : 0;

--- a/src/RulesetEngine/Context.php
+++ b/src/RulesetEngine/Context.php
@@ -62,6 +62,11 @@ final class Context
         });
     }
 
+    public function hasUncovered(): bool
+    {
+        return count($this->uncovered()) > 0;
+    }
+
     /**
      * @return Allowed[]
      */


### PR DESCRIPTION
Here is a patch to allow failure if uncovered cases are found.

I could not find any test to cover the changes made to the command nor the Context object, if tests are mandatory please explain where should I fit a test for this use-case.