### PR TITLE
Load Collectors by FQCN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor/*
 coverage/*
 tools/
+.box_dump/
 deptrac.phar
 deptrac.phar.asc
 depfile.yml

--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ layers:
 
 ### Custom Collectors
 
-You can even create custom collectors in your project by implementing the `CollectorInterface`.
+You can even create custom collectors in your project by implementing the `SensioLabs\Deptrac\Collector\CollectorInterface`.
 As soon as a unknown collector is referenced in the config file deptrac will try to load the class in your project.
 With this you can create collectors specific for your usecase. And more people can use these custom collectors per default if you contribute them back to deptrac!
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ With the `exclude_files` section, you can specify one or more regular expression
 the most common being probably anything containing the "test" word in the path.
 
 We defined three `layers` in the example: *Controller*, *Repository* and *Service*.
-Deptrac is using so called `collectors` to group classes into `layers` (in this case by the name of the class).
+Deptrac is using so called `collectors` to group classes into `layers`. You can define it by the name of the class or by the FQCN.
 
 The `ruleset` section defines, how these layers may or may not depend on other layers.
 In the example, every class of the *Controller* layer may depend on classes that reside in the *Service* layer,
@@ -596,9 +596,11 @@ layers:
         inherits: 'App\SomeInterface'
 ```
 
-### More Collectors
+### Custom Collectors
 
-As deptrac is in a very early state, feel free to contribute your own collector.
+You can even create custom collectors in your project by implementing the `CollectorInterface`.
+As soon as a unknown collector is referenced in the config file deptrac will try to load the class in your project.
+With this you can create collectors specific for your usecase. And more people can use these custom collectors per default if you contribute them back to deptrac!
 
 
 ## Formatters

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ this rule was violated.
     1. [`bool` Collector](#bool-collector)
     1. [`method` Collector](#method-collector)
     1. [`implements` Collector](#implements-collector)
-    1. [More Collectors](#more-collectors)
+    1. [Custom Collectors](#custom-collectors)
 1. [Formatters](#formatters)
     1. [Console Formatter](#console-formatter)
     1. [Graphviz Formatter](#graphviz-formatter)

--- a/box.json.dist
+++ b/box.json.dist
@@ -5,5 +5,8 @@
   ],
   "compression": "GZ",
   "main": "deptrac.php",
-  "git-version": "git-version"
+  "git-version": "git-version",
+  "compactors" : [
+      "KevinGH\\Box\\Compactor\\PhpScoper"
+  ]
 }

--- a/config/cache.php
+++ b/config/cache.php
@@ -16,7 +16,7 @@ return static function (di\ContainerConfigurator $container): void {
 
     $services
         ->set(CacheableFileSubscriber::class)
-        ->args([di\ref(AstFileReferenceCache::class)])
+        ->args([di\service(AstFileReferenceCache::class)])
         ->tag('event_subscriber');
 
     $services

--- a/deptrac.php
+++ b/deptrac.php
@@ -10,6 +10,12 @@ if (PHP_VERSION_ID < 70205) {
     exit(1);
 }
 
+$autoloaderInWorkingDirectory = getcwd() . '/vendor/autoload.php';
+
+if (is_file($autoloaderInWorkingDirectory)) {
+    require_once($autoloaderInWorkingDirectory);
+}
+
 $xdebug = new XdebugHandler('DEPTRAC', '--ansi');
 $xdebug->check();
 unset($xdebug);

--- a/deptrac.php
+++ b/deptrac.php
@@ -10,10 +10,10 @@ if (PHP_VERSION_ID < 70205) {
     exit(1);
 }
 
-$autoloaderInWorkingDirectory = getcwd() . '/vendor/autoload.php';
+$autoloaderInWorkingDirectory = getcwd().'/vendor/autoload.php';
 
 if (is_file($autoloaderInWorkingDirectory)) {
-    require_once($autoloaderInWorkingDirectory);
+    require_once $autoloaderInWorkingDirectory;
 }
 
 $xdebug = new XdebugHandler('DEPTRAC', '--ansi');

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -7,7 +7,9 @@ return [
     'finders' => [],                        // Finder[]
     'patchers' => [],                       // callable[]
     'files-whitelist' => [],                // string[]
-    'whitelist' => [],                      // string[]
+    'whitelist' => [
+        'SensioLabs\Deptrac\*',
+    ],
     'whitelist-global-constants' => true,   // bool
     'whitelist-global-classes' => true,     // bool
     'whitelist-global-functions' => true,   // bool

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'prefix' => null,                       // string|null
+    'finders' => [],                        // Finder[]
+    'patchers' => [],                       // callable[]
+    'files-whitelist' => [],                // string[]
+    'whitelist' => [],                      // string[]
+    'whitelist-global-constants' => true,   // bool
+    'whitelist-global-classes' => true,     // bool
+    'whitelist-global-functions' => true,   // bool
+];

--- a/src/Collector/Registry.php
+++ b/src/Collector/Registry.php
@@ -24,11 +24,24 @@ class Registry
      */
     public function getCollector(string $type): CollectorInterface
     {
-        if (!isset($this->collectors[$type])) {
-            throw new \InvalidArgumentException(sprintf('unknown collector type "%s", possible collectors are %s', $type, implode(', ', array_keys($this->collectors))));
+        if (array_key_exists($type, $this->collectors)) {
+            return $this->collectors[$type];
         }
 
-        return $this->collectors[$type];
+        foreach ($this->collectors as $collector) {
+            if (get_class($collector) === $type) {
+                return $collector;
+            }
+        }
+
+        if (class_exists($type) && is_subclass_of($type, CollectorInterface::class)) {
+            $collector = new $type();
+            $this->addCollector($collector);
+
+            return $collector;
+        }
+
+        throw new \InvalidArgumentException(sprintf('unknown collector type "%s", possible collectors are %s', $type, implode(', ', array_keys($this->collectors))));
     }
 
     private function addCollector(CollectorInterface $collector): void

--- a/tests/Collector/RegistryTest.php
+++ b/tests/Collector/RegistryTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\SensioLabs\Deptrac\Collector;
 
 use PHPUnit\Framework\TestCase;
+use SensioLabs\Deptrac\Collector\BoolCollector;
+use SensioLabs\Deptrac\Collector\ClassNameCollector;
 use SensioLabs\Deptrac\Collector\CollectorInterface;
 use SensioLabs\Deptrac\Collector\Registry;
 
@@ -29,5 +31,45 @@ class RegistryTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         (new Registry([]))->getCollector('foo');
+    }
+
+    public function testGetCollectorByFQCN(): void
+    {
+        $classNameCollector = new ClassNameCollector();
+        $registry = new Registry([$classNameCollector]);
+
+        static::assertSame($classNameCollector, $registry->getCollector(ClassNameCollector::class));
+    }
+
+    public function testGetUnknownCollectorByFQCN(): void
+    {
+        $classNameCollector = new ClassNameCollector();
+        $registry = new Registry([$classNameCollector]);
+
+        $collector = $registry->getCollector(BoolCollector::class);
+
+        static::assertNotSame($classNameCollector, $collector);
+        static::assertInstanceOf(BoolCollector::class, $collector);
+    }
+
+    public function testGetCollectorByFQCNLoadFromCache(): void
+    {
+        $classNameCollector = new ClassNameCollector();
+        $registry = new Registry([$classNameCollector]);
+
+        $collector = $registry->getCollector(ClassNameCollector::class);
+
+        static::assertInstanceOf(ClassNameCollector::class, $collector);
+        static::assertSame($collector, $registry->getCollector(ClassNameCollector::class));
+    }
+
+    public function testGetUnknownCollectorByFQCNAndThenByTypeFromCache(): void
+    {
+        $registry = new Registry([]);
+
+        $collector = $registry->getCollector(ClassNameCollector::class);
+
+        static::assertInstanceOf(ClassNameCollector::class, $collector);
+        static::assertSame($collector, $registry->getCollector('className'));
     }
 }


### PR DESCRIPTION
This patch enables the registry to load collectors by FQCN if not already present in the cache the missing object gets initiated and added to the cache.

Should fix #164 