### PR TITLE
Enable GithubActionsOutputFormatter by default in GithubActions environment

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,9 @@
         <testsuite name="Tests">
             <directory suffix="Test.php">./tests/</directory>
         </testsuite>
+        <testsuite name="phpt">
+            <directory suffix=".phpt">./tests/phpt</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist>

--- a/src/Env.php
+++ b/src/Env.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SensioLabs\Deptrac;
+
+class Env
+{
+    /**
+     * @return string|false Environment variable value or false if the variable does not exist
+     */
+    public function get(string $name)
+    {
+        return getenv($name);
+    }
+}

--- a/src/OutputFormatter/ConsoleOutputFormatter.php
+++ b/src/OutputFormatter/ConsoleOutputFormatter.php
@@ -6,6 +6,7 @@ namespace SensioLabs\Deptrac\OutputFormatter;
 
 use SensioLabs\Deptrac\AstRunner\AstMap\FileOccurrence;
 use SensioLabs\Deptrac\Dependency\InheritDependency;
+use SensioLabs\Deptrac\Env;
 use SensioLabs\Deptrac\RulesetEngine\Context;
 use SensioLabs\Deptrac\RulesetEngine\Rule;
 use SensioLabs\Deptrac\RulesetEngine\SkippedViolation;
@@ -15,6 +16,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class ConsoleOutputFormatter implements OutputFormatterInterface
 {
     private const REPORT_UNCOVERED = 'report-uncovered';
+
+    private $env;
+
+    public function __construct(Env $env = null)
+    {
+        $this->env = $env ?? new Env();
+    }
 
     public function getName(): string
     {
@@ -30,7 +38,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
 
     public function enabledByDefault(): bool
     {
-        return true;
+        return !(false !== $this->env->get('GITHUB_ACTIONS'));
     }
 
     public function finish(

--- a/src/OutputFormatter/GithubActionsOutputFormatter.php
+++ b/src/OutputFormatter/GithubActionsOutputFormatter.php
@@ -2,6 +2,7 @@
 
 namespace SensioLabs\Deptrac\OutputFormatter;
 
+use SensioLabs\Deptrac\Env;
 use SensioLabs\Deptrac\RulesetEngine\Context;
 use SensioLabs\Deptrac\RulesetEngine\Rule;
 use SensioLabs\Deptrac\RulesetEngine\SkippedViolation;
@@ -10,6 +11,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class GithubActionsOutputFormatter implements OutputFormatterInterface
 {
+    private $env;
+
+    public function __construct(Env $env = null)
+    {
+        $this->env = $env ?? new Env();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -28,7 +36,7 @@ class GithubActionsOutputFormatter implements OutputFormatterInterface
 
     public function enabledByDefault(): bool
     {
-        return false;
+        return false !== $this->env->get('GITHUB_ACTIONS');
     }
 
     /**

--- a/tests/EmptyEnv.php
+++ b/tests/EmptyEnv.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SensioLabs\Deptrac;
+
+use SensioLabs\Deptrac\Env;
+
+final class EmptyEnv extends Env
+{
+    public function get(string $envName)
+    {
+        return false;
+    }
+}

--- a/tests/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -148,7 +148,7 @@ class ConsoleOutputFormatterTest extends TestCase
         return str_replace(["\r", "\t", "\n", ' '], '', $str);
     }
 
-    public function testConsoleOutputFormatterIsActiveByDefault(): void
+    public function testConsoleOutputFormatterIsEnabledByDefault(): void
     {
         static::assertTrue((new ConsoleOutputFormatter(new EmptyEnv()))->enabledByDefault());
     }

--- a/tests/OutputFormatter/ConsoleOutputFormatterTest.php
+++ b/tests/OutputFormatter/ConsoleOutputFormatterTest.php
@@ -16,12 +16,13 @@ use SensioLabs\Deptrac\RulesetEngine\Context;
 use SensioLabs\Deptrac\RulesetEngine\SkippedViolation;
 use SensioLabs\Deptrac\RulesetEngine\Violation;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\SensioLabs\Deptrac\EmptyEnv;
 
 class ConsoleOutputFormatterTest extends TestCase
 {
     public function testGetName(): void
     {
-        static::assertEquals('console', (new ConsoleOutputFormatter())->getName());
+        static::assertEquals('console', (new ConsoleOutputFormatter(new EmptyEnv()))->getName());
     }
 
     public function basicDataProvider(): iterable
@@ -123,7 +124,7 @@ class ConsoleOutputFormatterTest extends TestCase
     {
         $output = new BufferedOutput();
 
-        $formatter = new ConsoleOutputFormatter();
+        $formatter = new ConsoleOutputFormatter(new EmptyEnv());
         $formatter->finish(
             new Context($rules),
             $output,
@@ -139,11 +140,16 @@ class ConsoleOutputFormatterTest extends TestCase
 
     public function testGetOptions(): void
     {
-        static::assertCount(1, (new ConsoleOutputFormatter())->configureOptions());
+        static::assertCount(1, (new ConsoleOutputFormatter(new EmptyEnv()))->configureOptions());
     }
 
     private function normalize($str)
     {
         return str_replace(["\r", "\t", "\n", ' '], '', $str);
+    }
+
+    public function testConsoleOutputFormatterIsActiveByDefault(): void
+    {
+        static::assertTrue((new ConsoleOutputFormatter(new EmptyEnv()))->enabledByDefault());
     }
 }

--- a/tests/OutputFormatter/GithubActionsOutputFormatterTest.php
+++ b/tests/OutputFormatter/GithubActionsOutputFormatterTest.php
@@ -76,7 +76,7 @@ class GithubActionsOutputFormatterTest extends TestCase
         ];
     }
 
-    public function testConsoleOutputFormatterIsActiveByDefault(): void
+    public function testGithubActionsOutputFormatterIsActiveByDefault(): void
     {
         static::assertFalse((new GithubActionsOutputFormatter(new EmptyEnv()))->enabledByDefault());
     }

--- a/tests/OutputFormatter/GithubActionsOutputFormatterTest.php
+++ b/tests/OutputFormatter/GithubActionsOutputFormatterTest.php
@@ -76,7 +76,7 @@ class GithubActionsOutputFormatterTest extends TestCase
         ];
     }
 
-    public function testGithubActionsOutputFormatterIsActiveByDefault(): void
+    public function testGithubActionsOutputFormatterIsNotEnabledByDefault(): void
     {
         static::assertFalse((new GithubActionsOutputFormatter(new EmptyEnv()))->enabledByDefault());
     }

--- a/tests/OutputFormatter/GithubActionsOutputFormatterTest.php
+++ b/tests/OutputFormatter/GithubActionsOutputFormatterTest.php
@@ -12,6 +12,7 @@ use SensioLabs\Deptrac\RulesetEngine\Context;
 use SensioLabs\Deptrac\RulesetEngine\SkippedViolation;
 use SensioLabs\Deptrac\RulesetEngine\Violation;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\SensioLabs\Deptrac\EmptyEnv;
 
 class GithubActionsOutputFormatterTest extends TestCase
 {
@@ -73,5 +74,10 @@ class GithubActionsOutputFormatterTest extends TestCase
             ],
             "::warning file=/home/testuser/originalA.php,line=12::[SKIPPED] ACME\OriginalA must not depend on ACME\OriginalB (LayerA on LayerB)\n",
         ];
+    }
+
+    public function testConsoleOutputFormatterIsActiveByDefault(): void
+    {
+        static::assertFalse((new GithubActionsOutputFormatter(new EmptyEnv()))->enabledByDefault());
     }
 }

--- a/tests/phpt/Env.phpt
+++ b/tests/phpt/Env.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Access environment variables
+--ENV--
+FOO=true
+TEST=test
+--FILE--
+<?php
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$env = new \SensioLabs\Deptrac\Env();
+
+var_dump($env->get('FOO'));
+var_dump($env->get('BAR'));
+var_dump($env->get('TEST'));
+
+--EXPECT--
+string(4) "true"
+bool(false)
+string(4) "test"

--- a/tests/phpt/GithubActionsOutputFormatterIsActiveByDefaultInGitHubActionsEnvironment.phpt
+++ b/tests/phpt/GithubActionsOutputFormatterIsActiveByDefaultInGitHubActionsEnvironment.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Access environment variables
+--ENV--
+GITHUB_ACTIONS=true
+--FILE--
+<?php
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+var_dump((new \SensioLabs\Deptrac\OutputFormatter\ConsoleOutputFormatter())->enabledByDefault());
+var_dump((new \SensioLabs\Deptrac\OutputFormatter\GithubActionsOutputFormatter())->enabledByDefault());
+
+--EXPECT--
+bool(false)
+bool(true)


### PR DESCRIPTION
fixes #318 