### PR TITLE
Fix: Reject duplicate layer names

### DIFF
--- a/src/Configuration/Exception/InvalidConfigurationException.php
+++ b/src/Configuration/Exception/InvalidConfigurationException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SensioLabs\Deptrac\Configuration\Exception;
+
+final class InvalidConfigurationException extends \InvalidArgumentException
+{
+    public static function fromDuplicateLayerNames(string ...$layerNames): self
+    {
+        natsort($layerNames);
+
+        return new self(sprintf(
+            'Configuration can not contain multiple layers with the same name, got "%s" as duplicate.',
+            implode('", "', $layerNames)
+        ));
+    }
+}

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -7,9 +7,56 @@ namespace Tests\SensioLabs\Deptrac\Configuration;
 use PHPUnit\Framework\TestCase;
 use SensioLabs\Deptrac\AstRunner\AstMap\ClassLikeName;
 use SensioLabs\Deptrac\Configuration\Configuration;
+use SensioLabs\Deptrac\Configuration\Exception;
 
+/**
+ * @covers \SensioLabs\Deptrac\Configuration\Configuration
+ */
 class ConfigurationTest extends TestCase
 {
+    public function testFromArrayRejectsLayersWithDuplicateNames(): void
+    {
+        $this->expectException(Exception\InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Configuration can not contain multiple layers with the same name, got "baz", "foo" as duplicate.');
+
+        Configuration::fromArray([
+            'layers' => [
+                [
+                   'name' => 'foo',
+                   'collectors' => [],
+                ],
+                [
+                   'name' => 'foo',
+                   'collectors' => [],
+                ],
+                [
+                   'name' => 'bar',
+                   'collectors' => [],
+                ],
+                [
+                   'name' => 'baz',
+                   'collectors' => [],
+                ],
+                [
+                   'name' => 'baz',
+                   'collectors' => [],
+                ],
+            ],
+            'paths' => [
+                'src',
+            ],
+            'ruleset' => [
+                'foo' => [
+                    'bar',
+                ],
+                'bar' => null,
+                'baz' => [
+                    'bar',
+                ],
+            ],
+        ]);
+    }
+
     public function testFromArray(): void
     {
         $configuration = Configuration::fromArray([
@@ -19,7 +66,7 @@ class ConfigurationTest extends TestCase
                    'collectors' => [],
                 ],
                 [
-                   'name' => 'some_name',
+                   'name' => 'some_other_name',
                    'collectors' => [],
                 ],
             ],
@@ -53,7 +100,7 @@ class ConfigurationTest extends TestCase
                    'collectors' => [],
                 ],
                 [
-                   'name' => 'some_name',
+                   'name' => 'some_other_name',
                    'collectors' => [],
                 ],
             ],

--- a/tests/Configuration/Exception/InvalidConfigurationExceptionTest.php
+++ b/tests/Configuration/Exception/InvalidConfigurationExceptionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SensioLabs\Deptrac\Configuration\Exception;
+
+use PHPUnit\Framework\TestCase;
+use SensioLabs\Deptrac\Configuration\Exception\InvalidConfigurationException;
+
+/**
+ * @covers \SensioLabs\Deptrac\Configuration\Exception\InvalidConfigurationException
+ */
+final class InvalidConfigurationExceptionTest extends TestCase
+{
+    public function testIsInvalidArgumentException(): void
+    {
+        $exception = new InvalidConfigurationException();
+
+        self::assertInstanceOf(\InvalidArgumentException::class, $exception);
+    }
+
+    public function testFromDuplicateLayerNamesReturnsException(): void
+    {
+        $layerNames = [
+            'foo',
+            'bar',
+        ];
+
+        $exception = InvalidConfigurationException::fromDuplicateLayerNames(...$layerNames);
+
+        natsort($layerNames);
+
+        $message = sprintf(
+            'Configuration can not contain multiple layers with the same name, got "%s" as duplicate.',
+            implode('", "', $layerNames)
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}


### PR DESCRIPTION
This PR

* [x] rejects duplicate layer names

💁‍♂️ Not sure if is by design, but I can't see a reason why anyone would need to define multiple layers with the same name. Instead they probably want to define multiple collectors.
