### PR TITLE
Fix: Reject rule sets referencing unknown layers

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -68,6 +68,22 @@ class Configuration
             throw Exception\InvalidConfigurationException::fromDuplicateLayerNames(...$duplicateLayerNames);
         }
 
+        $layerNamesUsedInRuleset = array_unique(array_merge(
+            array_keys($options['ruleset']),
+            ...array_values(array_map(static function (?array $rules): array {
+                return (array) $rules;
+            }, $options['ruleset']))
+        ));
+
+        $unknownLayerNames = array_diff(
+            $layerNamesUsedInRuleset,
+            $layerNames
+        );
+
+        if ([] !== $unknownLayerNames) {
+            throw Exception\InvalidConfigurationException::fromUnknownLayerNames(...$unknownLayerNames);
+        }
+
         $this->ruleset = ConfigurationRuleset::fromArray($options['ruleset']);
         $this->paths = $options['paths'];
         $this->skipViolations = ConfigurationSkippedViolation::fromArray($options['skip_violations']);

--- a/src/Configuration/Exception/InvalidConfigurationException.php
+++ b/src/Configuration/Exception/InvalidConfigurationException.php
@@ -15,4 +15,14 @@ final class InvalidConfigurationException extends \InvalidArgumentException
             implode('", "', $layerNames)
         ));
     }
+
+    public static function fromUnknownLayerNames(string ...$layerNames): self
+    {
+        natsort($layerNames);
+
+        return new self(sprintf(
+            'Configuration can not reference rule sets with unknown layer names, got "%s" as unknown.',
+            implode('", "', $layerNames)
+        ));
+    }
 }

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -57,6 +57,43 @@ class ConfigurationTest extends TestCase
         ]);
     }
 
+    public function testFromArrayRejectsRulesetUsingUnknownLayerNames(): void
+    {
+        $this->expectException(Exception\InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Configuration can not reference rule sets with unknown layer names, got "quux", "qux" as unknown.');
+
+        Configuration::fromArray([
+            'layers' => [
+                [
+                   'name' => 'foo',
+                   'collectors' => [],
+                ],
+                [
+                   'name' => 'bar',
+                   'collectors' => [],
+                ],
+                [
+                   'name' => 'baz',
+                   'collectors' => [],
+                ],
+            ],
+            'paths' => [
+                'src',
+            ],
+            'ruleset' => [
+                'foo' => [
+                    'bar',
+                ],
+                'bar' => null,
+                'baz' => [
+                    'bar',
+                    'qux',
+                ],
+                'quux' => null,
+            ],
+        ]);
+    }
+
     public function testFromArray(): void
     {
         $configuration = Configuration::fromArray([
@@ -66,7 +103,11 @@ class ConfigurationTest extends TestCase
                    'collectors' => [],
                 ],
                 [
-                   'name' => 'some_other_name',
+                   'name' => 'xx',
+                   'collectors' => [],
+                ],
+                [
+                   'name' => 'yy',
                    'collectors' => [],
                 ],
             ],
@@ -79,15 +120,15 @@ class ConfigurationTest extends TestCase
                 'bar2',
             ],
             'ruleset' => [
-                'lala' => ['xx', 'yy'],
+                'some_name' => ['xx', 'yy'],
             ],
         ]);
 
-        static::assertCount(2, $configuration->getLayers());
+        static::assertCount(3, $configuration->getLayers());
         static::assertEquals('some_name', $configuration->getLayers()[0]->getName());
         static::assertEquals(['foo', 'bar'], $configuration->getPaths());
         static::assertEquals(['foo2', 'bar2'], $configuration->getExcludeFiles());
-        static::assertEquals(['xx', 'yy'], $configuration->getRuleset()->getAllowedDependencies('lala'));
+        static::assertEquals(['xx', 'yy'], $configuration->getRuleset()->getAllowedDependencies('some_name'));
         static::assertTrue($configuration->ignoreUncoveredInternalClasses());
     }
 
@@ -109,7 +150,7 @@ class ConfigurationTest extends TestCase
                 'bar',
             ],
             'ruleset' => [
-                'lala' => ['xx', 'yy'],
+                'some_name' => ['some_other_name'],
             ],
         ]);
 

--- a/tests/Configuration/Exception/InvalidConfigurationExceptionTest.php
+++ b/tests/Configuration/Exception/InvalidConfigurationExceptionTest.php
@@ -37,4 +37,23 @@ final class InvalidConfigurationExceptionTest extends TestCase
 
         self::assertSame($message, $exception->getMessage());
     }
+
+    public function testFromUnknownLayerNamesReturnsException(): void
+    {
+        $layerNames = [
+            'foo',
+            'bar',
+        ];
+
+        $exception = InvalidConfigurationException::fromUnknownLayerNames(...$layerNames);
+
+        natsort($layerNames);
+
+        $message = sprintf(
+            'Configuration can not reference rule sets with unknown layer names, got "%s" as unknown.',
+            implode('", "', $layerNames)
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
 }

--- a/tests/RulesetEngineTest.php
+++ b/tests/RulesetEngineTest.php
@@ -13,6 +13,9 @@ use SensioLabs\Deptrac\Dependency\Dependency;
 use SensioLabs\Deptrac\Dependency\Result;
 use SensioLabs\Deptrac\RulesetEngine;
 
+/**
+ * @covers \SensioLabs\Deptrac\RulesetEngine
+ */
 class RulesetEngineTest extends TestCase
 {
     private function createDependencies(array $fromTo): iterable
@@ -39,6 +42,16 @@ class RulesetEngineTest extends TestCase
                 'ClassB' => ['LayerB'],
             ],
             [
+                [
+                    'name' => 'LayerA',
+                    'collectors' => [],
+                ],
+                [
+                    'name' => 'LayerB',
+                    'collectors' => [],
+                ],
+            ],
+            [
                 'LayerA' => [
                     'LayerB',
                 ],
@@ -55,6 +68,16 @@ class RulesetEngineTest extends TestCase
                 'ClassB' => ['LayerB'],
             ],
             [
+                [
+                    'name' => 'LayerA',
+                    'collectors' => [],
+                ],
+                [
+                    'name' => 'LayerB',
+                    'collectors' => [],
+                ],
+            ],
+            [
                 'LayerA' => [],
                 'LayerB' => [],
             ],
@@ -69,6 +92,16 @@ class RulesetEngineTest extends TestCase
                 'ClassA' => ['LayerA'],
                 'ClassB' => ['LayerB'],
             ],
+            [
+                [
+                    'name' => 'LayerA',
+                    'collectors' => [],
+                ],
+                [
+                    'name' => 'LayerB',
+                    'collectors' => [],
+                ],
+            ],
             [],
             1,
         ];
@@ -82,6 +115,7 @@ class RulesetEngineTest extends TestCase
                 'ClassB' => [],
             ],
             [],
+            [],
             0,
         ];
 
@@ -92,6 +126,16 @@ class RulesetEngineTest extends TestCase
             [
                 'ClassA' => ['LayerA'],
                 'ClassB' => ['LayerB'],
+            ],
+            [
+                [
+                    'name' => 'LayerA',
+                    'collectors' => [],
+                ],
+                [
+                    'name' => 'LayerB',
+                    'collectors' => [],
+                ],
             ],
             [
                 'LayerA' => ['LayerB'],
@@ -106,6 +150,16 @@ class RulesetEngineTest extends TestCase
             [
                 'ClassA' => ['LayerA'],
                 'ClassB' => ['LayerB'],
+            ],
+            [
+                [
+                    'name' => 'LayerA',
+                    'collectors' => [],
+                ],
+                [
+                    'name' => 'LayerB',
+                    'collectors' => [],
+                ],
             ],
             [
                 'LayerB' => ['LayerA'],
@@ -125,6 +179,24 @@ class RulesetEngineTest extends TestCase
                 'ClassC' => ['LayerC'],
                 'ClassD' => ['LayerD'],
             ],
+            [
+                [
+                    'name' => 'LayerA',
+                    'collectors' => [],
+                ],
+                [
+                    'name' => 'LayerB',
+                    'collectors' => [],
+                ],
+                [
+                    'name' => 'LayerC',
+                    'collectors' => [],
+                ],
+                [
+                    'name' => 'LayerD',
+                    'collectors' => [],
+                ],
+            ],
             [],
             3,
         ];
@@ -136,6 +208,12 @@ class RulesetEngineTest extends TestCase
             [
                 'ClassA' => ['LayerA'],
             ],
+            [
+                [
+                    'name' => 'LayerA',
+                    'collectors' => [],
+                ],
+            ],
             [],
             0,
         ];
@@ -144,8 +222,13 @@ class RulesetEngineTest extends TestCase
     /**
      * @dataProvider dependencyProvider
      */
-    public function testProcess(array $dependenciesAsArray, array $classesInLayers, array $rulesetConfiguration, int $expectedCount): void
-    {
+    public function testProcess(
+        array $dependenciesAsArray,
+        array $classesInLayers,
+        array $layersConfiguration,
+        array $rulesetConfiguration,
+        int $expectedCount
+    ): void {
         $dependencyResult = new Result();
         foreach ($this->createDependencies($dependenciesAsArray) as $dep) {
             $dependencyResult->addDependency($dep);
@@ -157,7 +240,7 @@ class RulesetEngineTest extends TestCase
         }
 
         $configuration = Configuration::fromArray([
-            'layers' => [],
+            'layers' => $layersConfiguration,
             'paths' => [],
             'ruleset' => $rulesetConfiguration,
         ]);


### PR DESCRIPTION
This PR

* [x] rejects rule sets referencing unknown layers

💁‍♂️ During the weekend I ran into an issue because I had a typo in a ruleset.