### PR TITLE
Readme: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ layers:
     collectors:
       - type: className
         regex: .*MyNamespace\\.*Controller.*
-ruleset: ~
+ruleset: []
 ```
 
 At first, lets take a closer look at the first layer (named *Models*).


### PR DESCRIPTION
the example as-is leads to an error:

```
> deptrac analyze app/portal/depfile.yml

In OptionsResolver.php line 877:
  The option "ruleset" with value null is expected to be of type "array", but is of type "null".
```