### PR TITLE
replace useless specific output file to temp file at test.

### DIFF
--- a/tests/OutputFormatter/BaselineOutputFormatterTest.php
+++ b/tests/OutputFormatter/BaselineOutputFormatterTest.php
@@ -98,7 +98,7 @@ class BaselineOutputFormatterTest extends TestCase
      */
     public function testBasic(array $rules, string $expectedOutput): void
     {
-        $generatedBaselineFile = __DIR__.'/data/generated-baseline.yml';
+        $generatedBaselineFile = tempnam(sys_get_temp_dir(), 'deptrac_');
         $output = new BufferedOutput();
 
         $formatter = new BaselineOutputFormatter();
@@ -112,6 +112,7 @@ class BaselineOutputFormatterTest extends TestCase
             $expectedOutput,
             file_get_contents($generatedBaselineFile)
         );
+        unlink($generatedBaselineFile);
     }
 
     public function testGetOptions(): void

--- a/tests/OutputFormatter/data/generated-baseline.yml
+++ b/tests/OutputFormatter/data/generated-baseline.yml
@@ -1,3 +1,0 @@
-skip_violations:
-  ClassA:
-    ClassB: ClassB


### PR DESCRIPTION
Currently, `tests/OutputFormatter/data/generated-baseline.yml` is committed that result of basicDataProvider data set #0.

After developer running test, `generated-baseline.yml` file will be chagned with other data set.

eg.
```
$ git diff
diff --git a/tests/OutputFormatter/data/generated-baseline.yml b/tests/OutputFormatter/data/generated-baseline.yml
index 1c28cb2..c3af77a 100644
--- a/tests/OutputFormatter/data/generated-baseline.yml
+++ b/tests/OutputFormatter/data/generated-baseline.yml
@@ -1,3 +1,3 @@
 skip_violations:
-  ClassA:
-    ClassB: ClassB
+  OriginalA:
+    - OriginalB
```

Because, PHPUnit would randomly test for dataProvider data set.
```
$ ./tools/phpunit.phar --testdox --filter "testBasic" tests/OutputFormatter/BaselineOutputFormatterTest.php
PHPUnit 8.5.13 by Sebastian Bergmann and contributors.

Random seed:   1611926497

Baseline Output Formatter (Tests\SensioLabs\Deptrac\OutputFormatter\BaselineOutputFormatter)
 ✔ Basic with data set 0
 ✔ Basic with data set 2
 ✔ Basic with data set 4
 ✔ Basic with data set 3
 ✔ Basic with data set 1

Time: 2.5 seconds, Memory: 14.00 MB

OK (5 tests, 5 assertions)
```

This `generated-baseline.yml` changes will be troubled when using `git commit -a -m` or other git commands under developing.
so, I propose this fix.